### PR TITLE
Make it possible to infer the generic type

### DIFF
--- a/SqlBulkTools.IntegrationTests/BulkOpearationsIT.cs
+++ b/SqlBulkTools.IntegrationTests/BulkOpearationsIT.cs
@@ -5,6 +5,7 @@ using System.Data;
 using System.Data.Entity;
 using System.Data.SqlClient;
 using System.Linq;
+using System.Xml;
 using NUnit.Framework;
 using Ploeh.AutoFixture;
 using SqlBulkTools.IntegrationTests.Data;
@@ -219,12 +220,13 @@ namespace SqlBulkTools.IntegrationTests
             BulkDelete(_db.Books.ToList());
 
             _bookCollection = _randomizer.GetRandomCollection(rows);
-            bulk.Setup<Book>()
-                .ForCollection(_bookCollection)
+            bulk.Setup() //<Book>()
+                .ForCollection(_bookCollection.Select(x => new {ColumnName1 = x.Description, ColumnName2 = x.ISBN}))
                 .WithTable("Books")
-                .AddAllColumns()
-                .BulkInsert()
-                .SetIdentityColumn(x => x.Id, ColumnDirection.InputOutput);
+                .AddColumn(x => x.ColumnName1)
+                .AddColumn(x => x.ColumnName2)
+                .BulkInsert();
+                //.SetIdentityColumn(x => x.Id, ColumnDirection.InputOutput);
 
             bulk.CommitTransaction("SqlBulkToolsTest");
 

--- a/SqlBulkTools.IntegrationTests/BulkOpearationsIT.cs
+++ b/SqlBulkTools.IntegrationTests/BulkOpearationsIT.cs
@@ -690,7 +690,7 @@ namespace SqlBulkTools.IntegrationTests
         }
 
 
-
+       
 
         [Test]
         public void SqlBulkTools_BulkUpdateWithSelectedColumns_TestIdentityOutput()

--- a/SqlBulkTools.IntegrationTests/BulkOpearationsIT.cs
+++ b/SqlBulkTools.IntegrationTests/BulkOpearationsIT.cs
@@ -5,7 +5,6 @@ using System.Data;
 using System.Data.Entity;
 using System.Data.SqlClient;
 using System.Linq;
-using System.Xml;
 using NUnit.Framework;
 using Ploeh.AutoFixture;
 using SqlBulkTools.IntegrationTests.Data;
@@ -220,13 +219,12 @@ namespace SqlBulkTools.IntegrationTests
             BulkDelete(_db.Books.ToList());
 
             _bookCollection = _randomizer.GetRandomCollection(rows);
-            bulk.Setup() //<Book>()
-                .ForCollection(_bookCollection.Select(x => new {ColumnName1 = x.Description, ColumnName2 = x.ISBN}))
+            bulk.Setup<Book>()
+                .ForCollection(_bookCollection)
                 .WithTable("Books")
-                .AddColumn(x => x.ColumnName1)
-                .AddColumn(x => x.ColumnName2)
-                .BulkInsert();
-                //.SetIdentityColumn(x => x.Id, ColumnDirection.InputOutput);
+                .AddAllColumns()
+                .BulkInsert()
+                .SetIdentityColumn(x => x.Id, ColumnDirection.InputOutput);
 
             bulk.CommitTransaction("SqlBulkToolsTest");
 
@@ -692,7 +690,7 @@ namespace SqlBulkTools.IntegrationTests
         }
 
 
-       
+
 
         [Test]
         public void SqlBulkTools_BulkUpdateWithSelectedColumns_TestIdentityOutput()

--- a/SqlBulkTools/BulkOperations/BulkOperations.cs
+++ b/SqlBulkTools/BulkOperations/BulkOperations.cs
@@ -129,6 +129,14 @@ namespace SqlBulkTools
             return new Setup<T>(this);
         }
 
+        /// <summary>
+        /// Each transaction requires a valid setup. Examples available at: https://github.com/gtaylor44/SqlBulkTools 
+        /// </summary>
+        /// <returns></returns>
+        public Setup Setup()
+        {
+            return new Setup(this);
+        }
 
     }
 

--- a/SqlBulkTools/BulkOperations/Setup.cs
+++ b/SqlBulkTools/BulkOperations/Setup.cs
@@ -6,6 +6,33 @@ namespace SqlBulkTools
     /// <summary>
     /// 
     /// </summary>
+    public class Setup
+    {
+        private readonly BulkOperations _ext;
+
+        /// <summary>
+        /// 
+        /// </summary>
+        /// <param name="ext"></param>
+        public Setup(BulkOperations ext)
+        {
+            _ext = ext;
+        }
+
+        /// <summary>
+        /// Represents the collection of objects to be inserted/upserted/updated/deleted (configured in next steps). 
+        /// </summary>
+        /// <param name="list"></param>
+        /// <returns></returns>
+        public CollectionSelect<T> ForCollection<T>(IEnumerable<T> list)
+        {
+            return new CollectionSelect<T>(list, _ext);
+        }
+    }
+
+    /// <summary>
+    /// 
+    /// </summary>
     /// <typeparam name="T"></typeparam>
     public class Setup<T>
     {


### PR DESCRIPTION
Make it possible to infer the generic type and by that making it possible to use anonymous types. By doing this we can avoid having to create custom classes with the same name as the columns in the database.
Example:
```
bulk.Setup()
        .ForCollection(_bookCollection.Select(x => new
        {
               ColumnName1 = x.Description,
               ColumnName2 = x.ISBN
         }))
        .WithTable("Books")
        .AddColumn(x => x.ColumnName1)
        .AddColumn(x => x.ColumnName2)
        .BulkInsert();
```
And for the normal case instead of:
`bulk.Setup<Book>().ForCollection(books)`
We can just write:
`bulk.Setup().ForCollection(books)`