### PR TITLE
Supporting using an existing connection and transaction

### DIFF
--- a/SqlBulkTools.jmconfig
+++ b/SqlBulkTools.jmconfig
@@ -1,0 +1,1 @@
+﻿<?xml version="1.0" encoding="utf-8"?><Configuration xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:xsd="http://www.w3.org/2001/XMLSchema"><DontShowAgainInSolution>false</DontShowAgainInSolution></Configuration>

--- a/SqlBulkTools/BulkOperations/BulkCopy/BulkDelete.cs
+++ b/SqlBulkTools/BulkOperations/BulkCopy/BulkDelete.cs
@@ -127,7 +127,7 @@ namespace SqlBulkTools
 				conn.Open();
 				handleConnectionInternally = true;
 			}
-			var dtCols = BulkOperationsHelper.GetDatabaseSchema( conn, _schema, _tableName );
+			var dtCols = BulkOperationsHelper.GetDatabaseSchema( conn, _schema, _tableName, transaction );
 
 			bool handleTransactionInternally = false;
 			if ( transaction == null )
@@ -257,7 +257,7 @@ namespace SqlBulkTools
 				await conn.OpenAsync();
 				handleConnectionInternally = true;
 			}
-			var dtCols = BulkOperationsHelper.GetDatabaseSchema( conn, _schema, _tableName );
+			var dtCols = BulkOperationsHelper.GetDatabaseSchema( conn, _schema, _tableName, transaction );
 
 			bool handleTransactionInternally = false;
 			if ( transaction == null )

--- a/SqlBulkTools/BulkOperations/BulkCopy/BulkDelete.cs
+++ b/SqlBulkTools/BulkOperations/BulkCopy/BulkDelete.cs
@@ -9,309 +9,351 @@ using System.Threading.Tasks;
 // ReSharper disable once CheckNamespace
 namespace SqlBulkTools
 {
-    /// <summary>
-    /// 
-    /// </summary>
-    /// <typeparam name="T"></typeparam>
-    public class BulkDelete<T> : AbstractOperation<T>, ITransaction
-    {
-        /// <summary>
-        /// 
-        /// </summary>
-        /// <param name="list"></param>
-        /// <param name="tableName"></param>
-        /// <param name="schema"></param>
-        /// <param name="columns"></param>
-        /// <param name="disableAllIndexes"></param>
-        /// <param name="customColumnMappings"></param>
-        /// <param name="sqlTimeout"></param>
-        /// <param name="bulkCopyTimeout"></param>
-        /// <param name="bulkCopyEnableStreaming"></param>
-        /// <param name="bulkCopyNotifyAfter"></param>
-        /// <param name="bulkCopyBatchSize"></param>
-        /// <param name="sqlBulkCopyOptions"></param>
-        /// <param name="ext"></param>
-        /// <param name="disableIndexList"></param>
-        /// <param name="bulkCopyDelegates"></param>
-        public BulkDelete(IEnumerable<T> list, string tableName, string schema, HashSet<string> columns, HashSet<string> disableIndexList, 
-            bool disableAllIndexes,
-            Dictionary<string, string> customColumnMappings, int sqlTimeout, int bulkCopyTimeout,
-            bool bulkCopyEnableStreaming, int? bulkCopyNotifyAfter, int? bulkCopyBatchSize, SqlBulkCopyOptions sqlBulkCopyOptions, 
-            BulkOperations ext, IEnumerable<SqlRowsCopiedEventHandler> bulkCopyDelegates)            
-            :
-            base(list, tableName, schema, columns, disableIndexList, disableAllIndexes, customColumnMappings, sqlTimeout,
-                bulkCopyTimeout, bulkCopyEnableStreaming, bulkCopyNotifyAfter, bulkCopyBatchSize, sqlBulkCopyOptions, ext, bulkCopyDelegates)
-        {
-            _ext.SetBulkExt(this);
-            _deletePredicates = new List<Condition>();
-            _parameters = new List<SqlParameter>();
-            _conditionSortOrder = 1;
-        }
+	/// <summary>
+	/// 
+	/// </summary>
+	/// <typeparam name="T"></typeparam>
+	public class BulkDelete<T> : AbstractOperation<T>, ITransaction
+	{
+		/// <summary>
+		/// 
+		/// </summary>
+		/// <param name="list"></param>
+		/// <param name="tableName"></param>
+		/// <param name="schema"></param>
+		/// <param name="columns"></param>
+		/// <param name="disableAllIndexes"></param>
+		/// <param name="customColumnMappings"></param>
+		/// <param name="sqlTimeout"></param>
+		/// <param name="bulkCopyTimeout"></param>
+		/// <param name="bulkCopyEnableStreaming"></param>
+		/// <param name="bulkCopyNotifyAfter"></param>
+		/// <param name="bulkCopyBatchSize"></param>
+		/// <param name="sqlBulkCopyOptions"></param>
+		/// <param name="ext"></param>
+		/// <param name="disableIndexList"></param>
+		/// <param name="bulkCopyDelegates"></param>
+		public BulkDelete( IEnumerable<T> list, string tableName, string schema, HashSet<string> columns, HashSet<string> disableIndexList,
+			bool disableAllIndexes,
+			Dictionary<string, string> customColumnMappings, int sqlTimeout, int bulkCopyTimeout,
+			bool bulkCopyEnableStreaming, int? bulkCopyNotifyAfter, int? bulkCopyBatchSize, SqlBulkCopyOptions sqlBulkCopyOptions,
+			BulkOperations ext, IEnumerable<SqlRowsCopiedEventHandler> bulkCopyDelegates )
+			:
+			base( list, tableName, schema, columns, disableIndexList, disableAllIndexes, customColumnMappings, sqlTimeout,
+				bulkCopyTimeout, bulkCopyEnableStreaming, bulkCopyNotifyAfter, bulkCopyBatchSize, sqlBulkCopyOptions, ext, bulkCopyDelegates )
+		{
+			_ext.SetBulkExt( this );
+			_deletePredicates = new List<Condition>();
+			_parameters = new List<SqlParameter>();
+			_conditionSortOrder = 1;
+		}
 
-        /// <summary>
-        /// At least one MatchTargetOn is required for correct configuration. MatchTargetOn is the matching clause for evaluating 
-        /// each row in table. This is usally set to the unique identifier in the table (e.g. Id). Multiple MatchTargetOn members are allowed 
-        /// for matching composite relationships. 
-        /// </summary>
-        /// <param name="columnName"></param>
-        /// <returns></returns>
-        public BulkDelete<T> MatchTargetOn(Expression<Func<T, object>> columnName)
-        {
-            var propertyName = BulkOperationsHelper.GetPropertyName(columnName);
-            _matchTargetOn.Add(propertyName);
-            return this;
-        }
+		/// <summary>
+		/// At least one MatchTargetOn is required for correct configuration. MatchTargetOn is the matching clause for evaluating 
+		/// each row in table. This is usally set to the unique identifier in the table (e.g. Id). Multiple MatchTargetOn members are allowed 
+		/// for matching composite relationships. 
+		/// </summary>
+		/// <param name="columnName"></param>
+		/// <returns></returns>
+		public BulkDelete<T> MatchTargetOn( Expression<Func<T, object>> columnName )
+		{
+			var propertyName = BulkOperationsHelper.GetPropertyName( columnName );
+			_matchTargetOn.Add( propertyName );
+			return this;
+		}
 
-        /// <summary>
-        /// Only delete records when the target satisfies a speicific requirement. This is used in conjunction with MatchTargetOn.
-        /// See help docs for examples.  
-        /// </summary>
-        /// <param name="predicate"></param>
-        /// <returns></returns>
-        public BulkDelete<T> DeleteWhen(Expression<Func<T, bool>> predicate)
-        {
-            BulkOperationsHelper.AddPredicate(predicate, PredicateType.Delete, _deletePredicates, _parameters, _conditionSortOrder, Constants.UniqueParamIdentifier);
-            _conditionSortOrder++;
+		/// <summary>
+		/// Only delete records when the target satisfies a speicific requirement. This is used in conjunction with MatchTargetOn.
+		/// See help docs for examples.  
+		/// </summary>
+		/// <param name="predicate"></param>
+		/// <returns></returns>
+		public BulkDelete<T> DeleteWhen( Expression<Func<T, bool>> predicate )
+		{
+			BulkOperationsHelper.AddPredicate( predicate, PredicateType.Delete, _deletePredicates, _parameters, _conditionSortOrder, Constants.UniqueParamIdentifier );
+			_conditionSortOrder++;
 
-            return this;
-        }
+			return this;
+		}
 
-        /// <summary>
-        /// Sets the identity column for the table. Required if an Identity column exists in table and one of the two 
-        /// following conditions is met: (1) MatchTargetOn list contains an identity column (2) AddAllColumns is used in setup. 
-        /// </summary>
-        /// <param name="columnName"></param>
-        /// <returns></returns>
-        public BulkDelete<T> SetIdentityColumn(Expression<Func<T, object>> columnName)
-        {
-            base.SetIdentity(columnName);
-            return this;
-        }
+		/// <summary>
+		/// Sets the identity column for the table. Required if an Identity column exists in table and one of the two 
+		/// following conditions is met: (1) MatchTargetOn list contains an identity column (2) AddAllColumns is used in setup. 
+		/// </summary>
+		/// <param name="columnName"></param>
+		/// <returns></returns>
+		public BulkDelete<T> SetIdentityColumn( Expression<Func<T, object>> columnName )
+		{
+			base.SetIdentity( columnName );
+			return this;
+		}
 
-        /// <summary>
-        /// Sets the identity column for the table. Required if an Identity column exists in table and one of the two 
-        /// following conditions is met: (1) MatchTargetOn list contains an identity column (2) AddAllColumns is used in setup. 
-        /// </summary>
-        /// <param name="columnName"></param>
-        /// <param name="outputIdentity"></param>
-        /// <returns></returns>
-        public BulkDelete<T> SetIdentityColumn(Expression<Func<T, object>> columnName, ColumnDirection outputIdentity)
-        {
-            base.SetIdentity(columnName, outputIdentity);
-            return this;
-        }
+		/// <summary>
+		/// Sets the identity column for the table. Required if an Identity column exists in table and one of the two 
+		/// following conditions is met: (1) MatchTargetOn list contains an identity column (2) AddAllColumns is used in setup. 
+		/// </summary>
+		/// <param name="columnName"></param>
+		/// <param name="outputIdentity"></param>
+		/// <returns></returns>
+		public BulkDelete<T> SetIdentityColumn( Expression<Func<T, object>> columnName, ColumnDirection outputIdentity )
+		{
+			base.SetIdentity( columnName, outputIdentity );
+			return this;
+		}
 
-        int ITransaction.CommitTransaction(string connectionName, SqlCredential credentials, SqlConnection connection)
-        {
-            int affectedRecords = 0;
-            if (!_list.Any())
-            {
-                return affectedRecords;
-            }
+		int ITransaction.CommitTransaction( string connectionName, SqlCredential credentials, SqlConnection connection, SqlTransaction transaction )
+		{
+			int affectedRecords = 0;
+			if ( !_list.Any() )
+			{
+				return affectedRecords;
+			}
 
-            base.IndexCheck();
-            base.MatchTargetCheck();
+			base.IndexCheck();
+			base.MatchTargetCheck();
 
-            DataTable dt = BulkOperationsHelper.CreateDataTable<T>(_columns, _customColumnMappings, _matchTargetOn, _outputIdentity);
-            dt = BulkOperationsHelper.ConvertListToDataTable(dt, _list, _columns, _outputIdentityDic);
+			DataTable dt = BulkOperationsHelper.CreateDataTable<T>( _columns, _customColumnMappings, _matchTargetOn, _outputIdentity );
+			dt = BulkOperationsHelper.ConvertListToDataTable( dt, _list, _columns, _outputIdentityDic );
 
-            // Must be after ToDataTable is called. 
-            BulkOperationsHelper.DoColumnMappings(_customColumnMappings, _columns);
-            BulkOperationsHelper.DoColumnMappings(_customColumnMappings, _deletePredicates);
+			// Must be after ToDataTable is called. 
+			BulkOperationsHelper.DoColumnMappings( _customColumnMappings, _columns );
+			BulkOperationsHelper.DoColumnMappings( _customColumnMappings, _deletePredicates );
 
-            using (SqlConnection conn = BulkOperationsHelper.GetSqlConnection(connectionName, credentials, connection))
-            {
-                conn.Open();
-                var dtCols = BulkOperationsHelper.GetDatabaseSchema(conn, _schema, _tableName);
+			bool handleConnectionInternally = false;
+			SqlConnection conn = BulkOperationsHelper.GetSqlConnection( connectionName, credentials, connection );
 
-                using (SqlTransaction transaction = conn.BeginTransaction())
-                {
+			if ( conn.State != ConnectionState.Open )
+			{
+				conn.Open();
+				handleConnectionInternally = true;
+			}
+			var dtCols = BulkOperationsHelper.GetDatabaseSchema( conn, _schema, _tableName );
 
-                    try
-                    {
-                        SqlCommand command = conn.CreateCommand();
-                        command.Connection = conn;
-                        command.Transaction = transaction;
-                        command.CommandTimeout = _sqlTimeout;
+			bool handleTransactionInternally = false;
+			if ( transaction == null )
+			{
+				transaction = conn.BeginTransaction();
+				handleTransactionInternally = true;
+			}
 
-                        //Creating temp table on database
-                        command.CommandText = BulkOperationsHelper.BuildCreateTempTable(_columns, dtCols, _outputIdentity);
-                        command.ExecuteNonQuery();
+			try
+			{
+				SqlCommand command = conn.CreateCommand();
+				command.Connection = conn;
+				command.Transaction = transaction;
+				command.CommandTimeout = _sqlTimeout;
 
-                        BulkOperationsHelper.InsertToTmpTable(conn, transaction, dt, _bulkCopyEnableStreaming,
-                            _bulkCopyBatchSize, _bulkCopyNotifyAfter, _bulkCopyTimeout, _sqlBulkCopyOptions, _bulkCopyDelegates);
+				//Creating temp table on database
+				command.CommandText = BulkOperationsHelper.BuildCreateTempTable( _columns, dtCols, _outputIdentity );
+				command.ExecuteNonQuery();
 
-                        if (_disableIndexList != null && _disableIndexList.Any())
-                        {
-                            command.CommandText = BulkOperationsHelper.GetIndexManagementCmd(IndexOperation.Disable, _tableName, 
-                                _schema, conn, _disableIndexList, _disableAllIndexes);
-                            command.ExecuteNonQuery();
-                        }
+				BulkOperationsHelper.InsertToTmpTable( conn, transaction, dt, _bulkCopyEnableStreaming,
+					_bulkCopyBatchSize, _bulkCopyNotifyAfter, _bulkCopyTimeout, _sqlBulkCopyOptions, _bulkCopyDelegates );
 
-                        string comm = BulkOperationsHelper.GetOutputCreateTableCmd(_outputIdentity, Constants.TempOutputTableName,
-                        OperationType.InsertOrUpdate, _identityColumn);
+				if ( _disableIndexList != null && _disableIndexList.Any() )
+				{
+					command.CommandText = BulkOperationsHelper.GetIndexManagementCmd( IndexOperation.Disable, _tableName,
+						_schema, conn, _disableIndexList, _disableAllIndexes );
+					command.ExecuteNonQuery();
+				}
 
-                        if (!string.IsNullOrWhiteSpace(comm))
-                        {
-                            command.CommandText = comm;
-                            command.ExecuteNonQuery();
-                        }
+				string comm = BulkOperationsHelper.GetOutputCreateTableCmd( _outputIdentity, Constants.TempOutputTableName,
+				OperationType.InsertOrUpdate, _identityColumn );
 
-                        comm = "MERGE INTO " + BulkOperationsHelper.GetFullQualifyingTableName(conn.Database, _schema, _tableName) + " WITH (HOLDLOCK) AS Target " +
-                                      "USING " + Constants.TempTableName + " AS Source " +
-                                      BulkOperationsHelper.BuildJoinConditionsForUpdateOrInsert(_matchTargetOn.ToArray(),
-                                      Constants.SourceAlias, Constants.TargetAlias) +
-                                      "WHEN MATCHED " + BulkOperationsHelper.BuildPredicateQuery(_matchTargetOn.ToArray(), _deletePredicates, Constants.TargetAlias) +
-                                      "THEN DELETE " +
-                                      BulkOperationsHelper.GetOutputIdentityCmd(_identityColumn, _outputIdentity, Constants.TempOutputTableName,
-                                      OperationType.Delete) + "; " +
-                                      "DROP TABLE " + Constants.TempTableName + ";";
-                        command.CommandText = comm;
+				if ( !string.IsNullOrWhiteSpace( comm ) )
+				{
+					command.CommandText = comm;
+					command.ExecuteNonQuery();
+				}
 
-                        if (_parameters.Count > 0)
-                        {
-                            command.Parameters.AddRange(_parameters.ToArray());
-                        }
+				comm = "MERGE INTO " + BulkOperationsHelper.GetFullQualifyingTableName( conn.Database, _schema, _tableName ) + " WITH (HOLDLOCK) AS Target " +
+							  "USING " + Constants.TempTableName + " AS Source " +
+							  BulkOperationsHelper.BuildJoinConditionsForUpdateOrInsert( _matchTargetOn.ToArray(),
+							  Constants.SourceAlias, Constants.TargetAlias ) +
+							  "WHEN MATCHED " + BulkOperationsHelper.BuildPredicateQuery( _matchTargetOn.ToArray(), _deletePredicates, Constants.TargetAlias ) +
+							  "THEN DELETE " +
+							  BulkOperationsHelper.GetOutputIdentityCmd( _identityColumn, _outputIdentity, Constants.TempOutputTableName,
+							  OperationType.Delete ) + "; " +
+							  "DROP TABLE " + Constants.TempTableName + ";";
+				command.CommandText = comm;
 
-                        affectedRecords = command.ExecuteNonQuery();
+				if ( _parameters.Count > 0 )
+				{
+					command.Parameters.AddRange( _parameters.ToArray() );
+				}
 
-                        if (_disableIndexList != null && _disableIndexList.Any())
-                        {
-                            command.CommandText = BulkOperationsHelper.GetIndexManagementCmd(IndexOperation.Rebuild, _tableName, 
-                                _schema, conn, _disableIndexList);
-                            command.ExecuteNonQuery();
-                        }
+				affectedRecords = command.ExecuteNonQuery();
 
-                        if (_outputIdentity == ColumnDirection.InputOutput)
-                        {
-                            BulkOperationsHelper.LoadFromTmpOutputTable(command, _identityColumn, _outputIdentityDic, OperationType.Delete, _list);
-                        }
+				if ( _disableIndexList != null && _disableIndexList.Any() )
+				{
+					command.CommandText = BulkOperationsHelper.GetIndexManagementCmd( IndexOperation.Rebuild, _tableName,
+						_schema, conn, _disableIndexList );
+					command.ExecuteNonQuery();
+				}
 
-                        transaction.Commit();
-                        return affectedRecords;
-                    }
-                    catch (Exception)
-                    {
-                        transaction.Rollback();
-                        throw;
-                    }
-                    finally
-                    {
-                        conn.Close();
-                    }
-                }
-            }
-        }
+				if ( _outputIdentity == ColumnDirection.InputOutput )
+				{
+					BulkOperationsHelper.LoadFromTmpOutputTable( command, _identityColumn, _outputIdentityDic, OperationType.Delete, _list );
+				}
 
-        /// <summary>
-        /// 
-        /// </summary>
-        /// <param name="connectionName"></param>
-        /// <param name="credentials"></param>
-        /// <param name="connection"></param>
-        /// <returns></returns>
-        async Task<int> ITransaction.CommitTransactionAsync(string connectionName, SqlCredential credentials, SqlConnection connection)
-        {
-            int affectedRows = 0;
-            if (!_list.Any())
-            {
-                return affectedRows;
-            }
-            base.IndexCheck();
-            base.MatchTargetCheck();
+				if ( handleTransactionInternally )
+				{
+					transaction.Commit();
+				}
+				return affectedRecords;
+			}
+			catch ( Exception )
+			{
+				if ( handleTransactionInternally )
+				{
+					transaction.Rollback();
+				}
+				throw;
+			}
+			finally
+			{
+				if ( handleTransactionInternally )
+				{
+					transaction.Dispose();
+				}
+				if ( handleConnectionInternally )
+				{
+					conn.Close();
+					conn.Dispose();
+				}
+			}
+		}
 
-            DataTable dt = BulkOperationsHelper.CreateDataTable<T>(_columns, _customColumnMappings, _matchTargetOn, _outputIdentity);
-            dt = BulkOperationsHelper.ConvertListToDataTable(dt, _list, _columns, _outputIdentityDic);
+		/// <summary>
+		/// 
+		/// </summary>
+		/// <param name="connectionName"></param>
+		/// <param name="credentials"></param>
+		/// <param name="connection"></param>
+		/// <param name="transaction"></param>
+		/// <returns></returns>
+		async Task<int> ITransaction.CommitTransactionAsync( string connectionName, SqlCredential credentials, SqlConnection connection, SqlTransaction transaction )
+		{
+			int affectedRows = 0;
+			if ( !_list.Any() )
+			{
+				return affectedRows;
+			}
+			base.IndexCheck();
+			base.MatchTargetCheck();
 
-            // Must be after ToDataTable is called. 
-            BulkOperationsHelper.DoColumnMappings(_customColumnMappings, _columns);
-            BulkOperationsHelper.DoColumnMappings(_customColumnMappings, _deletePredicates);
+			DataTable dt = BulkOperationsHelper.CreateDataTable<T>( _columns, _customColumnMappings, _matchTargetOn, _outputIdentity );
+			dt = BulkOperationsHelper.ConvertListToDataTable( dt, _list, _columns, _outputIdentityDic );
+
+			// Must be after ToDataTable is called. 
+			BulkOperationsHelper.DoColumnMappings( _customColumnMappings, _columns );
+			BulkOperationsHelper.DoColumnMappings( _customColumnMappings, _deletePredicates );
 
 
-            using (SqlConnection conn = BulkOperationsHelper.GetSqlConnection(connectionName, credentials, connection))
-            {
-                await conn.OpenAsync();
-                var dtCols = BulkOperationsHelper.GetDatabaseSchema(conn, _schema, _tableName);
+			bool handleConnectionInternally = false;
+			SqlConnection conn = BulkOperationsHelper.GetSqlConnection( connectionName, credentials, connection );
+			if ( conn.State != ConnectionState.Open )
+			{
+				await conn.OpenAsync();
+				handleConnectionInternally = true;
+			}
+			var dtCols = BulkOperationsHelper.GetDatabaseSchema( conn, _schema, _tableName );
 
-                using (SqlTransaction transaction = conn.BeginTransaction())
-                {
-                    try
-                    {
-                        SqlCommand command = conn.CreateCommand();
-                        command.Connection = conn;
-                        command.Transaction = transaction;
-                        command.CommandTimeout = _sqlTimeout;
+			bool handleTransactionInternally = false;
+			if ( transaction == null )
+			{
+				transaction = conn.BeginTransaction();
+				handleTransactionInternally = true;
+			}
+			try
+			{
+				SqlCommand command = conn.CreateCommand();
+				command.Connection = conn;
+				command.Transaction = transaction;
+				command.CommandTimeout = _sqlTimeout;
 
-                        //Creating temp table on database
-                        command.CommandText = BulkOperationsHelper.BuildCreateTempTable(_columns, dtCols, _outputIdentity);
-                        await command.ExecuteNonQueryAsync();
+				//Creating temp table on database
+				command.CommandText = BulkOperationsHelper.BuildCreateTempTable( _columns, dtCols, _outputIdentity );
+				await command.ExecuteNonQueryAsync();
 
-                        await BulkOperationsHelper.InsertToTmpTableAsync(conn, transaction, dt, _bulkCopyEnableStreaming, _bulkCopyBatchSize, 
-                            _bulkCopyNotifyAfter, _bulkCopyTimeout, _sqlBulkCopyOptions, _bulkCopyDelegates);
+				await BulkOperationsHelper.InsertToTmpTableAsync( conn, transaction, dt, _bulkCopyEnableStreaming, _bulkCopyBatchSize,
+					_bulkCopyNotifyAfter, _bulkCopyTimeout, _sqlBulkCopyOptions, _bulkCopyDelegates );
 
-                        if (_disableIndexList != null && _disableIndexList.Any())
-                        {
-                            command.CommandText = BulkOperationsHelper.GetIndexManagementCmd(IndexOperation.Disable, _tableName,
-                                _schema, conn, _disableIndexList, _disableAllIndexes);
-                            await command.ExecuteNonQueryAsync();
-                        }
+				if ( _disableIndexList != null && _disableIndexList.Any() )
+				{
+					command.CommandText = BulkOperationsHelper.GetIndexManagementCmd( IndexOperation.Disable, _tableName,
+						_schema, conn, _disableIndexList, _disableAllIndexes );
+					await command.ExecuteNonQueryAsync();
+				}
 
-                        string comm = BulkOperationsHelper.GetOutputCreateTableCmd(_outputIdentity, Constants.TempOutputTableName,
-                        OperationType.InsertOrUpdate, _identityColumn);
+				string comm = BulkOperationsHelper.GetOutputCreateTableCmd( _outputIdentity, Constants.TempOutputTableName,
+				OperationType.InsertOrUpdate, _identityColumn );
 
-                        if (!string.IsNullOrWhiteSpace(comm))
-                        {
-                            command.CommandText = comm;
-                            command.ExecuteNonQuery();
-                        }
+				if ( !string.IsNullOrWhiteSpace( comm ) )
+				{
+					command.CommandText = comm;
+					command.ExecuteNonQuery();
+				}
 
-                        // Updating destination table, and dropping temp table
-                        comm = "MERGE INTO " + BulkOperationsHelper.GetFullQualifyingTableName(conn.Database, _schema, _tableName) + " WITH (HOLDLOCK) AS Target " +
-                                      "USING " + Constants.TempTableName + " AS Source " +
-                                      BulkOperationsHelper.BuildJoinConditionsForUpdateOrInsert(_matchTargetOn.ToArray(),
-                                      Constants.SourceAlias, Constants.TargetAlias) +
-                                      "WHEN MATCHED " + BulkOperationsHelper.BuildPredicateQuery(_matchTargetOn.ToArray(), _deletePredicates, Constants.TargetAlias) + 
-                                      "THEN DELETE " +
-                                      BulkOperationsHelper.GetOutputIdentityCmd(_identityColumn, _outputIdentity, Constants.TempOutputTableName,
-                                      OperationType.Delete) + "; " + 
-                                      "DROP TABLE " + Constants.TempTableName + ";";
-                        command.CommandText = comm;
+				// Updating destination table, and dropping temp table
+				comm = "MERGE INTO " + BulkOperationsHelper.GetFullQualifyingTableName( conn.Database, _schema, _tableName ) + " WITH (HOLDLOCK) AS Target " +
+							  "USING " + Constants.TempTableName + " AS Source " +
+							  BulkOperationsHelper.BuildJoinConditionsForUpdateOrInsert( _matchTargetOn.ToArray(),
+							  Constants.SourceAlias, Constants.TargetAlias ) +
+							  "WHEN MATCHED " + BulkOperationsHelper.BuildPredicateQuery( _matchTargetOn.ToArray(), _deletePredicates, Constants.TargetAlias ) +
+							  "THEN DELETE " +
+							  BulkOperationsHelper.GetOutputIdentityCmd( _identityColumn, _outputIdentity, Constants.TempOutputTableName,
+							  OperationType.Delete ) + "; " +
+							  "DROP TABLE " + Constants.TempTableName + ";";
+				command.CommandText = comm;
 
-                        if (_parameters.Count > 0)
-                        {
-                            command.Parameters.AddRange(_parameters.ToArray());
-                        }
+				if ( _parameters.Count > 0 )
+				{
+					command.Parameters.AddRange( _parameters.ToArray() );
+				}
 
-                        affectedRows = await command.ExecuteNonQueryAsync();
+				affectedRows = await command.ExecuteNonQueryAsync();
 
-                        if (_disableIndexList != null && _disableIndexList.Any())
-                        {
-                            command.CommandText = BulkOperationsHelper.GetIndexManagementCmd(IndexOperation.Rebuild, _tableName, 
-                                _schema, conn, _disableIndexList);
-                            await command.ExecuteNonQueryAsync();
-                        }
+				if ( _disableIndexList != null && _disableIndexList.Any() )
+				{
+					command.CommandText = BulkOperationsHelper.GetIndexManagementCmd( IndexOperation.Rebuild, _tableName,
+						_schema, conn, _disableIndexList );
+					await command.ExecuteNonQueryAsync();
+				}
 
-                        if (_outputIdentity == ColumnDirection.InputOutput)
-                        {
-                            await
-                                BulkOperationsHelper.LoadFromTmpOutputTableAsync(command, _identityColumn, _outputIdentityDic,
-                                OperationType.Delete, _list);
-                        }
+				if ( _outputIdentity == ColumnDirection.InputOutput )
+				{
+					await
+						BulkOperationsHelper.LoadFromTmpOutputTableAsync( command, _identityColumn, _outputIdentityDic,
+						OperationType.Delete, _list );
+				}
 
-                        transaction.Commit();
-                        return affectedRows;
-                    }
-                    catch (Exception)
-                    {
-                        transaction.Rollback();
-                        throw;
-                    }
-                    finally
-                    {
-                        conn.Close();
-                    }
-                }
-            }
-        }
-    }
+				if ( handleTransactionInternally )
+				{
+					transaction.Commit();
+				}
+				return affectedRows;
+			}
+			catch ( Exception )
+			{
+				if ( handleTransactionInternally )
+				{
+					transaction.Rollback();
+				}
+				throw;
+			}
+			finally
+			{
+				if ( handleTransactionInternally )
+				{
+					transaction.Dispose();
+				}
+				if ( handleConnectionInternally )
+				{
+					conn.Close();
+					conn.Dispose();
+				}
+			}
+		}
+	}
 }

--- a/SqlBulkTools/BulkOperations/BulkCopy/BulkInsert.cs
+++ b/SqlBulkTools/BulkOperations/BulkCopy/BulkInsert.cs
@@ -9,269 +9,306 @@ using System.Threading.Tasks;
 // ReSharper disable once CheckNamespace
 namespace SqlBulkTools
 {
-    /// <summary>
-    /// 
-    /// </summary>
-    /// <typeparam name="T"></typeparam>
-    public class BulkInsert<T> : AbstractOperation<T>, ITransaction
-    {
-        /// <summary>
-        /// 
-        /// </summary>
-        /// <param name="list"></param>
-        /// <param name="tableName"></param>
-        /// <param name="schema"></param>
-        /// <param name="columns"></param>
-        /// <param name="disableIndexList"></param>
-        /// <param name="disableAllIndexes"></param>
-        /// <param name="customColumnMappings"></param>
-        /// <param name="sqlTimeout"></param>
-        /// <param name="bulkCopyTimeout"></param>
-        /// <param name="bulkCopyEnableStreaming"></param>
-        /// <param name="bulkCopyNotifyAfter"></param>
-        /// <param name="bulkCopyBatchSize"></param>
-        /// <param name="sqlBulkCopyOptions"></param>
-        /// <param name="ext"></param>
-        /// <param name="bulkCopyDelegates"></param>
-        public BulkInsert(IEnumerable<T> list, string tableName, string schema, HashSet<string> columns,
-            HashSet<string> disableIndexList, bool disableAllIndexes,
-            Dictionary<string, string> customColumnMappings, int sqlTimeout, int bulkCopyTimeout, bool bulkCopyEnableStreaming,
-            int? bulkCopyNotifyAfter, int? bulkCopyBatchSize, SqlBulkCopyOptions sqlBulkCopyOptions, BulkOperations ext, IEnumerable<SqlRowsCopiedEventHandler> bulkCopyDelegates) : 
+	/// <summary>
+	/// 
+	/// </summary>
+	/// <typeparam name="T"></typeparam>
+	public class BulkInsert<T> : AbstractOperation<T>, ITransaction
+	{
+		/// <summary>
+		/// 
+		/// </summary>
+		/// <param name="list"></param>
+		/// <param name="tableName"></param>
+		/// <param name="schema"></param>
+		/// <param name="columns"></param>
+		/// <param name="disableIndexList"></param>
+		/// <param name="disableAllIndexes"></param>
+		/// <param name="customColumnMappings"></param>
+		/// <param name="sqlTimeout"></param>
+		/// <param name="bulkCopyTimeout"></param>
+		/// <param name="bulkCopyEnableStreaming"></param>
+		/// <param name="bulkCopyNotifyAfter"></param>
+		/// <param name="bulkCopyBatchSize"></param>
+		/// <param name="sqlBulkCopyOptions"></param>
+		/// <param name="ext"></param>
+		/// <param name="bulkCopyDelegates"></param>
+		public BulkInsert( IEnumerable<T> list, string tableName, string schema, HashSet<string> columns,
+			HashSet<string> disableIndexList, bool disableAllIndexes,
+			Dictionary<string, string> customColumnMappings, int sqlTimeout, int bulkCopyTimeout, bool bulkCopyEnableStreaming,
+			int? bulkCopyNotifyAfter, int? bulkCopyBatchSize, SqlBulkCopyOptions sqlBulkCopyOptions, BulkOperations ext, IEnumerable<SqlRowsCopiedEventHandler> bulkCopyDelegates ) :
 
-            base(list, tableName, schema, columns, disableIndexList, disableAllIndexes, customColumnMappings, sqlTimeout,
-                bulkCopyTimeout, bulkCopyEnableStreaming, bulkCopyNotifyAfter, bulkCopyBatchSize, sqlBulkCopyOptions, ext, bulkCopyDelegates)
-        {
-            _ext.SetBulkExt(this);
-        }
+			base( list, tableName, schema, columns, disableIndexList, disableAllIndexes, customColumnMappings, sqlTimeout,
+				bulkCopyTimeout, bulkCopyEnableStreaming, bulkCopyNotifyAfter, bulkCopyBatchSize, sqlBulkCopyOptions, ext, bulkCopyDelegates )
+		{
+			_ext.SetBulkExt( this );
+		}
 
-        /// <summary>
-        /// Sets the identity column for the table. Required if an Identity column exists in table and one of the two 
-        /// following conditions is met: (1) MatchTargetOn list contains an identity column (2) AddAllColumns is used in setup. 
-        /// </summary>
-        /// <param name="columnName"></param>
-        /// <returns></returns>
-        public BulkInsert<T> SetIdentityColumn(Expression<Func<T, object>> columnName)
-        {
-            base.SetIdentity(columnName);
-            return this;
-        }
+		/// <summary>
+		/// Sets the identity column for the table. Required if an Identity column exists in table and one of the two 
+		/// following conditions is met: (1) MatchTargetOn list contains an identity column (2) AddAllColumns is used in setup. 
+		/// </summary>
+		/// <param name="columnName"></param>
+		/// <returns></returns>
+		public BulkInsert<T> SetIdentityColumn( Expression<Func<T, object>> columnName )
+		{
+			base.SetIdentity( columnName );
+			return this;
+		}
 
-        /// <summary>
-        /// Sets the identity column for the table. Required if an Identity column exists in table and one of the two 
-        /// following conditions is met: (1) MatchTargetOn list contains an identity column (2) AddAllColumns is used in setup. 
-        /// </summary>
-        /// <param name="columnName"></param>
-        /// <param name="outputIdentity"></param>
-        /// <returns></returns>
-        public BulkInsert<T> SetIdentityColumn(Expression<Func<T, object>> columnName, ColumnDirection outputIdentity)
-        {
-            base.SetIdentity(columnName, outputIdentity);
-            return this;
-        }
+		/// <summary>
+		/// Sets the identity column for the table. Required if an Identity column exists in table and one of the two 
+		/// following conditions is met: (1) MatchTargetOn list contains an identity column (2) AddAllColumns is used in setup. 
+		/// </summary>
+		/// <param name="columnName"></param>
+		/// <param name="outputIdentity"></param>
+		/// <returns></returns>
+		public BulkInsert<T> SetIdentityColumn( Expression<Func<T, object>> columnName, ColumnDirection outputIdentity )
+		{
+			base.SetIdentity( columnName, outputIdentity );
+			return this;
+		}
 
-        int ITransaction.CommitTransaction(string connectionName, SqlCredential credentials, SqlConnection connection)
-        {
+		int ITransaction.CommitTransaction( string connectionName, SqlCredential credentials, SqlConnection connection, SqlTransaction transaction )
+		{
 
-            int affectedRows = 0;
+			int affectedRows = 0;
 
-            if (!_list.Any())
-            {
-                return affectedRows;
-            }
+			if ( !_list.Any() )
+			{
+				return affectedRows;
+			}
 
-            base.IndexCheck();
+			base.IndexCheck();
 
-            DataTable dt = BulkOperationsHelper.CreateDataTable<T>(_columns, _customColumnMappings, _matchTargetOn, _outputIdentity);
-            dt = BulkOperationsHelper.ConvertListToDataTable(dt, _list, _columns);
-           
-            // Must be after ToDataTable is called. 
-            BulkOperationsHelper.DoColumnMappings(_customColumnMappings, _columns, _matchTargetOn);
+			DataTable dt = BulkOperationsHelper.CreateDataTable<T>( _columns, _customColumnMappings, _matchTargetOn, _outputIdentity );
+			dt = BulkOperationsHelper.ConvertListToDataTable( dt, _list, _columns );
 
-            using (SqlConnection conn = BulkOperationsHelper.GetSqlConnection(connectionName, credentials, connection))
-            {
+			// Must be after ToDataTable is called. 
+			BulkOperationsHelper.DoColumnMappings( _customColumnMappings, _columns, _matchTargetOn );
 
-                conn.Open();
-                DataTable dtCols = null;
-                if (_outputIdentity == ColumnDirection.InputOutput)
-                    dtCols = BulkOperationsHelper.GetDatabaseSchema(conn, _schema, _tableName);
+			bool handleConnectionInternally = false;
+			SqlConnection conn = BulkOperationsHelper.GetSqlConnection( connectionName, credentials, connection );
+			if ( conn.State != ConnectionState.Open )
+			{
+				conn.Open();
+				handleConnectionInternally = true;
+			}
+			DataTable dtCols = null;
+			if ( _outputIdentity == ColumnDirection.InputOutput )
+				dtCols = BulkOperationsHelper.GetDatabaseSchema( conn, _schema, _tableName );
 
-                using (SqlTransaction transaction = conn.BeginTransaction())
-                {
-                    //Bulk insert into temp table
-                    using (SqlBulkCopy bulkcopy = new SqlBulkCopy(conn, _sqlBulkCopyOptions, transaction))
-                    {
-                        try
-                        {
-                            bulkcopy.DestinationTableName = BulkOperationsHelper.GetFullQualifyingTableName(conn.Database, _schema, _tableName);
-                            BulkOperationsHelper.MapColumns(bulkcopy, _columns, _customColumnMappings);
+			bool handleTransactionInternally = false;
+			if ( transaction == null )
+			{
+				transaction = conn.BeginTransaction();
+				handleTransactionInternally = true;
+			}
+			//Bulk insert into temp table
+			using ( SqlBulkCopy bulkcopy = new SqlBulkCopy( conn, _sqlBulkCopyOptions, transaction ) )
+			{
+				try
+				{
+					bulkcopy.DestinationTableName = BulkOperationsHelper.GetFullQualifyingTableName( conn.Database, _schema, _tableName );
+					BulkOperationsHelper.MapColumns( bulkcopy, _columns, _customColumnMappings );
 
-                            BulkOperationsHelper.SetSqlBulkCopySettings(bulkcopy, _bulkCopyEnableStreaming, _bulkCopyBatchSize,
-                                _bulkCopyNotifyAfter, _bulkCopyTimeout, _bulkCopyDelegates);
+					BulkOperationsHelper.SetSqlBulkCopySettings( bulkcopy, _bulkCopyEnableStreaming, _bulkCopyBatchSize,
+						_bulkCopyNotifyAfter, _bulkCopyTimeout, _bulkCopyDelegates );
 
-                            SqlCommand command = conn.CreateCommand();
-                            command.Connection = conn;
-                            command.Transaction = transaction;
+					SqlCommand command = conn.CreateCommand();
+					command.Connection = conn;
+					command.Transaction = transaction;
 
-                            if (_disableAllIndexes || (_disableIndexList != null && _disableIndexList.Any()))
-                            {
-                                command.CommandText = BulkOperationsHelper.GetIndexManagementCmd(IndexOperation.Disable, _tableName, 
-                                    _schema, conn, _disableIndexList, _disableAllIndexes);
-                                command.ExecuteNonQuery();
-                            }
+					if ( _disableAllIndexes || ( _disableIndexList != null && _disableIndexList.Any() ) )
+					{
+						command.CommandText = BulkOperationsHelper.GetIndexManagementCmd( IndexOperation.Disable, _tableName,
+							_schema, conn, _disableIndexList, _disableAllIndexes );
+						command.ExecuteNonQuery();
+					}
 
-                            // If InputOutput identity is selected, must use staging table.
-                            if (_outputIdentity == ColumnDirection.InputOutput && dtCols != null)
-                            {
-                                command.CommandText = BulkOperationsHelper.BuildCreateTempTable(_columns, dtCols, _outputIdentity);
-                                command.ExecuteNonQuery();
+					// If InputOutput identity is selected, must use staging table.
+					if ( _outputIdentity == ColumnDirection.InputOutput && dtCols != null )
+					{
+						command.CommandText = BulkOperationsHelper.BuildCreateTempTable( _columns, dtCols, _outputIdentity );
+						command.ExecuteNonQuery();
 
-                                BulkOperationsHelper.InsertToTmpTable(conn, transaction, dt, _bulkCopyEnableStreaming, _bulkCopyBatchSize,
-                                    _bulkCopyNotifyAfter, _bulkCopyTimeout, _sqlBulkCopyOptions, _bulkCopyDelegates);
+						BulkOperationsHelper.InsertToTmpTable( conn, transaction, dt, _bulkCopyEnableStreaming, _bulkCopyBatchSize,
+							_bulkCopyNotifyAfter, _bulkCopyTimeout, _sqlBulkCopyOptions, _bulkCopyDelegates );
 
-                                command.CommandText = BulkOperationsHelper.GetInsertIntoStagingTableCmd(command, conn, _schema, _tableName,
-                                    _columns, _identityColumn, _outputIdentity);
-                                command.ExecuteNonQuery();
+						command.CommandText = BulkOperationsHelper.GetInsertIntoStagingTableCmd( command, conn, _schema, _tableName,
+							_columns, _identityColumn, _outputIdentity );
+						command.ExecuteNonQuery();
 
-                                BulkOperationsHelper.LoadFromTmpOutputTable(command, _identityColumn, _outputIdentityDic, OperationType.Insert, _list);
+						BulkOperationsHelper.LoadFromTmpOutputTable( command, _identityColumn, _outputIdentityDic, OperationType.Insert, _list );
 
-                            }
-                            
-                            else
-                                bulkcopy.WriteToServer(dt);
+					}
 
-                            if (_disableAllIndexes || (_disableIndexList != null && _disableIndexList.Any()))
-                            {
-                                command.CommandText = BulkOperationsHelper.GetIndexManagementCmd(IndexOperation.Rebuild, _tableName, 
-                                    _schema, conn, _disableIndexList, _disableAllIndexes);
-                                command.ExecuteNonQuery();
-                            }
+					else
+						bulkcopy.WriteToServer( dt );
 
-                            transaction.Commit();
-                            bulkcopy.Close();
+					if ( _disableAllIndexes || ( _disableIndexList != null && _disableIndexList.Any() ) )
+					{
+						command.CommandText = BulkOperationsHelper.GetIndexManagementCmd( IndexOperation.Rebuild, _tableName,
+							_schema, conn, _disableIndexList, _disableAllIndexes );
+						command.ExecuteNonQuery();
+					}
 
-                            affectedRows = dt.Rows.Count;
-                            return affectedRows;
-                        }
+					if ( handleTransactionInternally )
+					{
+						transaction.Commit();
+					}
+					bulkcopy.Close();
 
-                        catch (Exception)
-                        {
-                            transaction.Rollback();
-                            throw;
-                        }
-                        finally
-                        {
-                            conn.Close();
-                            
-                        }
-                    }
-                }
-            }
-        }
+					affectedRows = dt.Rows.Count;
+					return affectedRows;
+				}
 
-        /// <summary>
-        /// 
-        /// </summary>
-        /// <param name="connectionName"></param>
-        /// <param name="credentials"></param>
-        /// <param name="connection"></param>
-        /// <returns></returns>
-        async Task<int> ITransaction.CommitTransactionAsync(string connectionName, SqlCredential credentials, SqlConnection connection)
-        {
-            int affectedRows = 0;
-            if (!_list.Any())
-            {
-                return affectedRows;
-            }
+				catch ( Exception )
+				{
+					if ( handleTransactionInternally )
+					{
+						transaction.Rollback();
+					}
+					throw;
+				}
+				finally
+				{
+					if ( handleTransactionInternally )
+					{
+						transaction.Dispose();
+					}
+					if ( handleConnectionInternally )
+					{
+						conn.Close();
+						conn.Dispose();
+					}
+				}
+			}
+		}
 
-            base.IndexCheck();
+		/// <summary>
+		/// 
+		/// </summary>
+		/// <param name="connectionName"></param>
+		/// <param name="credentials"></param>
+		/// <param name="connection"></param>
+		/// <param name="transaction"></param>
+		/// <returns></returns>
+		async Task<int> ITransaction.CommitTransactionAsync( string connectionName, SqlCredential credentials, SqlConnection connection, SqlTransaction transaction )
+		{
+			int affectedRows = 0;
+			if ( !_list.Any() )
+			{
+				return affectedRows;
+			}
 
-            DataTable dt = BulkOperationsHelper.CreateDataTable<T>(_columns, _customColumnMappings, _matchTargetOn, _outputIdentity);
-            dt = BulkOperationsHelper.ConvertListToDataTable(dt, _list, _columns);
+			base.IndexCheck();
 
-            // Must be after ToDataTable is called. 
-            BulkOperationsHelper.DoColumnMappings(_customColumnMappings, _columns, _matchTargetOn);
+			DataTable dt = BulkOperationsHelper.CreateDataTable<T>( _columns, _customColumnMappings, _matchTargetOn, _outputIdentity );
+			dt = BulkOperationsHelper.ConvertListToDataTable( dt, _list, _columns );
 
-            using (SqlConnection conn = BulkOperationsHelper.GetSqlConnection(connectionName, credentials, connection))
-            {
+			// Must be after ToDataTable is called. 
+			BulkOperationsHelper.DoColumnMappings( _customColumnMappings, _columns, _matchTargetOn );
 
-                await conn.OpenAsync();
-                DataTable dtCols = null;
-                if (_outputIdentity == ColumnDirection.InputOutput)
-                    dtCols = BulkOperationsHelper.GetDatabaseSchema(conn, _schema, _tableName);
+			bool handleConnectionInternally = false;
+			SqlConnection conn = BulkOperationsHelper.GetSqlConnection( connectionName, credentials, connection );
+			if ( conn.State != ConnectionState.Open )
+			{
+				await conn.OpenAsync();
+				handleConnectionInternally = true;
+			}
+			DataTable dtCols = null;
+			if ( _outputIdentity == ColumnDirection.InputOutput )
+				dtCols = BulkOperationsHelper.GetDatabaseSchema( conn, _schema, _tableName );
 
-                using (SqlTransaction transaction = conn.BeginTransaction())
-                {
-                    //Bulk insert into temp table
-                    using (SqlBulkCopy bulkcopy = new SqlBulkCopy(conn, _sqlBulkCopyOptions, transaction))
-                    {
-                        try
-                        {
-                            bulkcopy.DestinationTableName = BulkOperationsHelper.GetFullQualifyingTableName(conn.Database, _schema, _tableName);
-                            BulkOperationsHelper.MapColumns(bulkcopy, _columns, _customColumnMappings);
+			bool handleTransactionInternally = false;
+			if ( transaction == null )
+			{
+				transaction = conn.BeginTransaction();
+				handleTransactionInternally = true;
+			}
+			//Bulk insert into temp table
+			using ( SqlBulkCopy bulkcopy = new SqlBulkCopy( conn, _sqlBulkCopyOptions, transaction ) )
+			{
+				try
+				{
+					bulkcopy.DestinationTableName = BulkOperationsHelper.GetFullQualifyingTableName( conn.Database, _schema, _tableName );
+					BulkOperationsHelper.MapColumns( bulkcopy, _columns, _customColumnMappings );
 
-                            BulkOperationsHelper.SetSqlBulkCopySettings(bulkcopy, _bulkCopyEnableStreaming, _bulkCopyBatchSize,
-                                _bulkCopyNotifyAfter, _bulkCopyTimeout, _bulkCopyDelegates);
+					BulkOperationsHelper.SetSqlBulkCopySettings( bulkcopy, _bulkCopyEnableStreaming, _bulkCopyBatchSize,
+						_bulkCopyNotifyAfter, _bulkCopyTimeout, _bulkCopyDelegates );
 
-                            SqlCommand command = conn.CreateCommand();
+					SqlCommand command = conn.CreateCommand();
 
-                            command.Connection = conn;
-                            command.Transaction = transaction;
+					command.Connection = conn;
+					command.Transaction = transaction;
 
-                            if (_disableAllIndexes || (_disableIndexList != null && _disableIndexList.Any()))
-                            {
-                                command.CommandText = BulkOperationsHelper.GetIndexManagementCmd(IndexOperation.Disable, _tableName, 
-                                    _schema, conn, _disableIndexList, _disableAllIndexes);
-                                await command.ExecuteNonQueryAsync();
-                            }
+					if ( _disableAllIndexes || ( _disableIndexList != null && _disableIndexList.Any() ) )
+					{
+						command.CommandText = BulkOperationsHelper.GetIndexManagementCmd( IndexOperation.Disable, _tableName,
+							_schema, conn, _disableIndexList, _disableAllIndexes );
+						await command.ExecuteNonQueryAsync();
+					}
 
-                            // If InputOutput identity is selected, must use staging table.
-                            if (_outputIdentity == ColumnDirection.InputOutput && dtCols != null)
-                            {
-                                command.CommandText = BulkOperationsHelper.BuildCreateTempTable(_columns, dtCols, _outputIdentity);
-                                await command.ExecuteNonQueryAsync();
+					// If InputOutput identity is selected, must use staging table.
+					if ( _outputIdentity == ColumnDirection.InputOutput && dtCols != null )
+					{
+						command.CommandText = BulkOperationsHelper.BuildCreateTempTable( _columns, dtCols, _outputIdentity );
+						await command.ExecuteNonQueryAsync();
 
-                                BulkOperationsHelper.InsertToTmpTable(conn, transaction, dt, _bulkCopyEnableStreaming, _bulkCopyBatchSize,
-                                    _bulkCopyNotifyAfter, _bulkCopyTimeout, _sqlBulkCopyOptions, _bulkCopyDelegates);
+						BulkOperationsHelper.InsertToTmpTable( conn, transaction, dt, _bulkCopyEnableStreaming, _bulkCopyBatchSize,
+							_bulkCopyNotifyAfter, _bulkCopyTimeout, _sqlBulkCopyOptions, _bulkCopyDelegates );
 
-                                command.CommandText = BulkOperationsHelper.GetInsertIntoStagingTableCmd(command, conn, _schema, _tableName,
-                                    _columns, _identityColumn, _outputIdentity);
-                                await command.ExecuteNonQueryAsync();
+						command.CommandText = BulkOperationsHelper.GetInsertIntoStagingTableCmd( command, conn, _schema, _tableName,
+							_columns, _identityColumn, _outputIdentity );
+						await command.ExecuteNonQueryAsync();
 
-                                await
-                                    BulkOperationsHelper.LoadFromTmpOutputTableAsync(command, _identityColumn, _outputIdentityDic,
-                                        OperationType.Insert, _list);
+						await
+							BulkOperationsHelper.LoadFromTmpOutputTableAsync( command, _identityColumn, _outputIdentityDic,
+								OperationType.Insert, _list );
 
-                            }
+					}
 
-                            else
-                                await bulkcopy.WriteToServerAsync(dt);
+					else
+						await bulkcopy.WriteToServerAsync( dt );
 
-                            if (_disableAllIndexes || (_disableIndexList != null && _disableIndexList.Any()))
-                            {
-                                command.CommandText = BulkOperationsHelper.GetIndexManagementCmd(IndexOperation.Rebuild, _tableName, _schema, 
-                                    conn, _disableIndexList, _disableAllIndexes);
-                                await command.ExecuteNonQueryAsync();
-                            }
-                            transaction.Commit();
-                            bulkcopy.Close();
+					if ( _disableAllIndexes || ( _disableIndexList != null && _disableIndexList.Any() ) )
+					{
+						command.CommandText = BulkOperationsHelper.GetIndexManagementCmd( IndexOperation.Rebuild, _tableName, _schema,
+							conn, _disableIndexList, _disableAllIndexes );
+						await command.ExecuteNonQueryAsync();
+					}
+					if ( handleTransactionInternally )
+					{
+						transaction.Commit();
+					}
+					bulkcopy.Close();
 
-                            affectedRows = dt.Rows.Count;
-                            return affectedRows;
-                        }
+					affectedRows = dt.Rows.Count;
+					return affectedRows;
+				}
 
-                        catch (Exception)
-                        {
-                            transaction.Rollback();
-                            throw;
-                        }
-                        finally
-                        {
-                            conn.Close();
-
-                        }
-                    }
-                }
-            }
-        }
-    }
+				catch ( Exception )
+				{
+					if ( handleTransactionInternally )
+					{
+						transaction.Rollback();
+					}
+					throw;
+				}
+				finally
+				{
+					if ( handleTransactionInternally )
+					{
+						transaction.Dispose();
+					}
+					if ( handleConnectionInternally )
+					{
+						conn.Close();
+						conn.Dispose();
+					}
+				}
+			}
+		}
+	}
 }

--- a/SqlBulkTools/BulkOperations/BulkCopy/BulkInsert.cs
+++ b/SqlBulkTools/BulkOperations/BulkCopy/BulkInsert.cs
@@ -96,7 +96,7 @@ namespace SqlBulkTools
 			}
 			DataTable dtCols = null;
 			if ( _outputIdentity == ColumnDirection.InputOutput )
-				dtCols = BulkOperationsHelper.GetDatabaseSchema( conn, _schema, _tableName );
+				dtCols = BulkOperationsHelper.GetDatabaseSchema( conn, _schema, _tableName, transaction );
 
 			bool handleTransactionInternally = false;
 			if ( transaction == null )
@@ -219,7 +219,7 @@ namespace SqlBulkTools
 			}
 			DataTable dtCols = null;
 			if ( _outputIdentity == ColumnDirection.InputOutput )
-				dtCols = BulkOperationsHelper.GetDatabaseSchema( conn, _schema, _tableName );
+				dtCols = BulkOperationsHelper.GetDatabaseSchema( conn, _schema, _tableName, transaction );
 
 			bool handleTransactionInternally = false;
 			if ( transaction == null )

--- a/SqlBulkTools/BulkOperations/BulkCopy/BulkInsertOrUpdate.cs
+++ b/SqlBulkTools/BulkOperations/BulkCopy/BulkInsertOrUpdate.cs
@@ -10,392 +10,437 @@ using System.Threading.Tasks;
 // ReSharper disable once CheckNamespace
 namespace SqlBulkTools
 {
-    /// <summary>
-    /// 
-    /// </summary>
-    /// <typeparam name="T"></typeparam>
-    public class BulkInsertOrUpdate<T> : AbstractOperation<T>, ITransaction
-    {
-        private bool _deleteWhenNotMatchedFlag;
+	/// <summary>
+	/// 
+	/// </summary>
+	/// <typeparam name="T"></typeparam>
+	public class BulkInsertOrUpdate<T> : AbstractOperation<T>, ITransaction
+	{
+		private bool _deleteWhenNotMatchedFlag;
 
-        /// <summary>
-        /// 
-        /// </summary>
-        /// <param name="list"></param>
-        /// <param name="tableName"></param>
-        /// <param name="schema"></param>
-        /// <param name="columns"></param>
-        /// <param name="disableIndexList"></param>
-        /// <param name="disableAllIndexes"></param>
-        /// <param name="customColumnMappings"></param>
-        /// <param name="sqlTimeout"></param>
-        /// <param name="bulkCopyTimeout"></param>
-        /// <param name="bulkCopyEnableStreaming"></param>
-        /// <param name="bulkCopyNotifyAfter"></param>
-        /// <param name="bulkCopyBatchSize"></param>
-        /// <param name="sqlBulkCopyOptions"></param>
-        /// <param name="ext"></param>
-        /// <param name="bulkCopyDelegates"></param>
-        public BulkInsertOrUpdate(IEnumerable<T> list, string tableName, string schema, HashSet<string> columns, HashSet<string> disableIndexList, bool disableAllIndexes,
-            Dictionary<string, string> customColumnMappings, int sqlTimeout, int bulkCopyTimeout, bool bulkCopyEnableStreaming,
-            int? bulkCopyNotifyAfter, int? bulkCopyBatchSize, SqlBulkCopyOptions sqlBulkCopyOptions, BulkOperations ext, IEnumerable<SqlRowsCopiedEventHandler> bulkCopyDelegates) :
+		/// <summary>
+		/// 
+		/// </summary>
+		/// <param name="list"></param>
+		/// <param name="tableName"></param>
+		/// <param name="schema"></param>
+		/// <param name="columns"></param>
+		/// <param name="disableIndexList"></param>
+		/// <param name="disableAllIndexes"></param>
+		/// <param name="customColumnMappings"></param>
+		/// <param name="sqlTimeout"></param>
+		/// <param name="bulkCopyTimeout"></param>
+		/// <param name="bulkCopyEnableStreaming"></param>
+		/// <param name="bulkCopyNotifyAfter"></param>
+		/// <param name="bulkCopyBatchSize"></param>
+		/// <param name="sqlBulkCopyOptions"></param>
+		/// <param name="ext"></param>
+		/// <param name="bulkCopyDelegates"></param>
+		public BulkInsertOrUpdate( IEnumerable<T> list, string tableName, string schema, HashSet<string> columns, HashSet<string> disableIndexList, bool disableAllIndexes,
+			Dictionary<string, string> customColumnMappings, int sqlTimeout, int bulkCopyTimeout, bool bulkCopyEnableStreaming,
+			int? bulkCopyNotifyAfter, int? bulkCopyBatchSize, SqlBulkCopyOptions sqlBulkCopyOptions, BulkOperations ext, IEnumerable<SqlRowsCopiedEventHandler> bulkCopyDelegates ) :
 
-            base(list, tableName, schema, columns, disableIndexList, disableAllIndexes, customColumnMappings, sqlTimeout,
-            bulkCopyTimeout, bulkCopyEnableStreaming, bulkCopyNotifyAfter, bulkCopyBatchSize, sqlBulkCopyOptions, ext, bulkCopyDelegates)
-        {
-            _ext.SetBulkExt(this);
-            _deleteWhenNotMatchedFlag = false;
-            _updatePredicates = new List<Condition>();
-            _deletePredicates = new List<Condition>();
-            _parameters = new List<SqlParameter>();
-            _conditionSortOrder = 1;
-        }
+			base( list, tableName, schema, columns, disableIndexList, disableAllIndexes, customColumnMappings, sqlTimeout,
+			bulkCopyTimeout, bulkCopyEnableStreaming, bulkCopyNotifyAfter, bulkCopyBatchSize, sqlBulkCopyOptions, ext, bulkCopyDelegates )
+		{
+			_ext.SetBulkExt( this );
+			_deleteWhenNotMatchedFlag = false;
+			_updatePredicates = new List<Condition>();
+			_deletePredicates = new List<Condition>();
+			_parameters = new List<SqlParameter>();
+			_conditionSortOrder = 1;
+		}
 
-        /// <summary>
-        /// At least one MatchTargetOn is required for correct configuration. MatchTargetOn is the matching clause for evaluating 
-        /// each row in table. This is usally set to the unique identifier in the table (e.g. Id). Multiple MatchTargetOn members are allowed 
-        /// for matching composite relationships. 
-        /// </summary>
-        /// <param name="columnName"></param>
-        /// <returns></returns>
-        public BulkInsertOrUpdate<T> MatchTargetOn(Expression<Func<T, object>> columnName)
-        {
-            var propertyName = BulkOperationsHelper.GetPropertyName(columnName);
+		/// <summary>
+		/// At least one MatchTargetOn is required for correct configuration. MatchTargetOn is the matching clause for evaluating 
+		/// each row in table. This is usally set to the unique identifier in the table (e.g. Id). Multiple MatchTargetOn members are allowed 
+		/// for matching composite relationships. 
+		/// </summary>
+		/// <param name="columnName"></param>
+		/// <returns></returns>
+		public BulkInsertOrUpdate<T> MatchTargetOn( Expression<Func<T, object>> columnName )
+		{
+			var propertyName = BulkOperationsHelper.GetPropertyName( columnName );
 
-            if (propertyName == null)
-                throw new NullReferenceException("MatchTargetOn column name can't be null.");
+			if ( propertyName == null )
+				throw new NullReferenceException( "MatchTargetOn column name can't be null." );
 
-            _matchTargetOn.Add(propertyName);
+			_matchTargetOn.Add( propertyName );
 
-            return this;
-        }
+			return this;
+		}
 
-        /// <summary>
-        /// Sets the identity column for the table. Required if an Identity column exists in table and one of the two 
-        /// following conditions is met: (1) MatchTargetOn list contains an identity column (2) AddAllColumns is used in setup. 
-        /// </summary>
-        /// <param name="columnName"></param>
-        /// <returns></returns>
-        public BulkInsertOrUpdate<T> SetIdentityColumn(Expression<Func<T, object>> columnName)
-        {
-            SetIdentity(columnName);
-            return this;
-        }
+		/// <summary>
+		/// Sets the identity column for the table. Required if an Identity column exists in table and one of the two 
+		/// following conditions is met: (1) MatchTargetOn list contains an identity column (2) AddAllColumns is used in setup. 
+		/// </summary>
+		/// <param name="columnName"></param>
+		/// <returns></returns>
+		public BulkInsertOrUpdate<T> SetIdentityColumn( Expression<Func<T, object>> columnName )
+		{
+			SetIdentity( columnName );
+			return this;
+		}
 
-        /// <summary>
-        /// Sets the identity column for the table. Required if an Identity column exists in table and one of the two 
-        /// following conditions is met: (1) MatchTargetOn list contains an identity column (2) AddAllColumns is used in setup. 
-        /// </summary>
-        /// <param name="columnName"></param>
-        /// <param name="outputIdentity"></param>
-        /// <returns></returns>
-        public BulkInsertOrUpdate<T> SetIdentityColumn(Expression<Func<T, object>> columnName, ColumnDirection outputIdentity)
-        {
-            base.SetIdentity(columnName, outputIdentity);
-            return this;
-        }
+		/// <summary>
+		/// Sets the identity column for the table. Required if an Identity column exists in table and one of the two 
+		/// following conditions is met: (1) MatchTargetOn list contains an identity column (2) AddAllColumns is used in setup. 
+		/// </summary>
+		/// <param name="columnName"></param>
+		/// <param name="outputIdentity"></param>
+		/// <returns></returns>
+		public BulkInsertOrUpdate<T> SetIdentityColumn( Expression<Func<T, object>> columnName, ColumnDirection outputIdentity )
+		{
+			base.SetIdentity( columnName, outputIdentity );
+			return this;
+		}
 
-        /// <summary>
-        /// Only delete records when the target satisfies a speicific requirement. This is used in conjunction with MatchTargetOn.
-        /// See help docs for examples. Notes: (1) DeleteWhenNotMatched must be set to true. 
-        /// </summary>
-        /// <param name="predicate"></param>
-        /// <returns></returns>
-        public BulkInsertOrUpdate<T> DeleteWhen(Expression<Func<T, bool>> predicate)
-        {
-            BulkOperationsHelper.AddPredicate(predicate, PredicateType.Delete, _deletePredicates, _parameters, _conditionSortOrder, Constants.UniqueParamIdentifier);
-            _conditionSortOrder++;
+		/// <summary>
+		/// Only delete records when the target satisfies a speicific requirement. This is used in conjunction with MatchTargetOn.
+		/// See help docs for examples. Notes: (1) DeleteWhenNotMatched must be set to true. 
+		/// </summary>
+		/// <param name="predicate"></param>
+		/// <returns></returns>
+		public BulkInsertOrUpdate<T> DeleteWhen( Expression<Func<T, bool>> predicate )
+		{
+			BulkOperationsHelper.AddPredicate( predicate, PredicateType.Delete, _deletePredicates, _parameters, _conditionSortOrder, Constants.UniqueParamIdentifier );
+			_conditionSortOrder++;
 
-            return this;
-        }
+			return this;
+		}
 
-        /// <summary>
-        /// Only update records when the target satisfies a speicific requirement. This is used in conjunction with MatchTargetOn.
-        /// See help docs for examples.  
-        /// </summary>
-        /// <param name="predicate"></param>
-        /// <returns></returns>
-        /// <exception cref="SqlBulkToolsException"></exception>
-        public BulkInsertOrUpdate<T> UpdateWhen(Expression<Func<T, bool>> predicate)
-        {
-            BulkOperationsHelper.AddPredicate(predicate, PredicateType.Update, _updatePredicates, _parameters, _conditionSortOrder, Constants.UniqueParamIdentifier);
-            _conditionSortOrder++;
+		/// <summary>
+		/// Only update records when the target satisfies a speicific requirement. This is used in conjunction with MatchTargetOn.
+		/// See help docs for examples.  
+		/// </summary>
+		/// <param name="predicate"></param>
+		/// <returns></returns>
+		/// <exception cref="SqlBulkToolsException"></exception>
+		public BulkInsertOrUpdate<T> UpdateWhen( Expression<Func<T, bool>> predicate )
+		{
+			BulkOperationsHelper.AddPredicate( predicate, PredicateType.Update, _updatePredicates, _parameters, _conditionSortOrder, Constants.UniqueParamIdentifier );
+			_conditionSortOrder++;
 
-            return this;
-        }
+			return this;
+		}
 
-        /// <summary>
-        /// If a target record can't be matched to a source record, it's deleted. Notes: (1) This is false by default. (2) Use at your own risk.
-        /// </summary>
-        /// <param name="flag"></param>
-        /// <returns></returns>
-        public BulkInsertOrUpdate<T> DeleteWhenNotMatched(bool flag)
-        {
-            _deleteWhenNotMatchedFlag = flag;
-            return this;
-        }
+		/// <summary>
+		/// If a target record can't be matched to a source record, it's deleted. Notes: (1) This is false by default. (2) Use at your own risk.
+		/// </summary>
+		/// <param name="flag"></param>
+		/// <returns></returns>
+		public BulkInsertOrUpdate<T> DeleteWhenNotMatched( bool flag )
+		{
+			_deleteWhenNotMatchedFlag = flag;
+			return this;
+		}
 
-        int ITransaction.CommitTransaction(string connectionName, SqlCredential credentials, SqlConnection connection)
-        {
-            int affectedRows = 0;
-            if (!_list.Any())
-            {
-                return affectedRows;
-            }
+		int ITransaction.CommitTransaction( string connectionName, SqlCredential credentials, SqlConnection connection, SqlTransaction transaction )
+		{
+			int affectedRows = 0;
+			if ( !_list.Any() )
+			{
+				return affectedRows;
+			}
 
-            if (!_deleteWhenNotMatchedFlag && _deletePredicates.Count > 0)
-                throw new SqlBulkToolsException($"{BulkOperationsHelper.GetPredicateMethodName(PredicateType.Delete)} only usable on BulkInsertOrUpdate " +
-                                                $"method when 'DeleteWhenNotMatched' is set to true.");
+			if ( !_deleteWhenNotMatchedFlag && _deletePredicates.Count > 0 )
+				throw new SqlBulkToolsException( $"{BulkOperationsHelper.GetPredicateMethodName( PredicateType.Delete )} only usable on BulkInsertOrUpdate " +
+												$"method when 'DeleteWhenNotMatched' is set to true." );
 
-            base.IndexCheck();
-            base.MatchTargetCheck();
+			base.IndexCheck();
+			base.MatchTargetCheck();
 
-            DataTable dt = BulkOperationsHelper.CreateDataTable<T>(_columns, _customColumnMappings, _matchTargetOn, _outputIdentity);
-            dt = BulkOperationsHelper.ConvertListToDataTable(dt, _list, _columns, _outputIdentityDic);
+			DataTable dt = BulkOperationsHelper.CreateDataTable<T>( _columns, _customColumnMappings, _matchTargetOn, _outputIdentity );
+			dt = BulkOperationsHelper.ConvertListToDataTable( dt, _list, _columns, _outputIdentityDic );
 
-            // Must be after ToDataTable is called. 
-            BulkOperationsHelper.DoColumnMappings(_customColumnMappings, _columns, _matchTargetOn);
-            BulkOperationsHelper.DoColumnMappings(_customColumnMappings, _deletePredicates);
-            BulkOperationsHelper.DoColumnMappings(_customColumnMappings, _updatePredicates);
+			// Must be after ToDataTable is called. 
+			BulkOperationsHelper.DoColumnMappings( _customColumnMappings, _columns, _matchTargetOn );
+			BulkOperationsHelper.DoColumnMappings( _customColumnMappings, _deletePredicates );
+			BulkOperationsHelper.DoColumnMappings( _customColumnMappings, _updatePredicates );
 
-            using (SqlConnection conn = BulkOperationsHelper.GetSqlConnection(connectionName, credentials, connection))
-            {
-                conn.Open();
-                var dtCols = BulkOperationsHelper.GetDatabaseSchema(conn, _schema, _tableName);
+			bool handleConnectionInternally = false;
+			SqlConnection conn = BulkOperationsHelper.GetSqlConnection( connectionName, credentials, connection );
+			if ( conn.State != ConnectionState.Open )
+			{
+				conn.Open();
+				handleConnectionInternally = true;
+			}
+			var dtCols = BulkOperationsHelper.GetDatabaseSchema( conn, _schema, _tableName );
 
-                using (SqlTransaction transaction = conn.BeginTransaction())
-                {
-                    try
-                    {
+			bool handleTransactionInternally = false;
+			if ( transaction == null )
+			{
+				transaction = conn.BeginTransaction();
+				handleTransactionInternally = true;
+			}
+			try
+			{
 
-                        SqlCommand command = conn.CreateCommand();                        
-                        
+				SqlCommand command = conn.CreateCommand();
 
-                        command.Connection = conn;
-                        command.Transaction = transaction;
-                        command.CommandTimeout = _sqlTimeout;
 
-                        //Creating temp table on database
-                        command.CommandText = BulkOperationsHelper.BuildCreateTempTable(_columns, dtCols, _outputIdentity);
-                        command.ExecuteNonQuery();
+				command.Connection = conn;
+				command.Transaction = transaction;
+				command.CommandTimeout = _sqlTimeout;
 
-                        BulkOperationsHelper.InsertToTmpTable(conn, transaction, dt, _bulkCopyEnableStreaming, _bulkCopyBatchSize,
-                            _bulkCopyNotifyAfter, _bulkCopyTimeout, _sqlBulkCopyOptions, _bulkCopyDelegates);
+				//Creating temp table on database
+				command.CommandText = BulkOperationsHelper.BuildCreateTempTable( _columns, dtCols, _outputIdentity );
+				command.ExecuteNonQuery();
 
-                        if (_disableIndexList != null && _disableIndexList.Any())
-                        {
-                            command.CommandText = BulkOperationsHelper.GetIndexManagementCmd(IndexOperation.Disable, _tableName,
-                                _schema, conn, _disableIndexList, _disableAllIndexes);
-                            command.ExecuteNonQuery();
-                        }
+				BulkOperationsHelper.InsertToTmpTable( conn, transaction, dt, _bulkCopyEnableStreaming, _bulkCopyBatchSize,
+					_bulkCopyNotifyAfter, _bulkCopyTimeout, _sqlBulkCopyOptions, _bulkCopyDelegates );
 
-                        string comm = BulkOperationsHelper.GetOutputCreateTableCmd(_outputIdentity, Constants.TempOutputTableName,
-                        OperationType.InsertOrUpdate, _identityColumn);
+				if ( _disableIndexList != null && _disableIndexList.Any() )
+				{
+					command.CommandText = BulkOperationsHelper.GetIndexManagementCmd( IndexOperation.Disable, _tableName,
+						_schema, conn, _disableIndexList, _disableAllIndexes );
+					command.ExecuteNonQuery();
+				}
 
-                        if (!string.IsNullOrWhiteSpace(comm))
-                        {
-                            command.CommandText = comm;
-                            command.ExecuteNonQuery();
-                        }
+				string comm = BulkOperationsHelper.GetOutputCreateTableCmd( _outputIdentity, Constants.TempOutputTableName,
+				OperationType.InsertOrUpdate, _identityColumn );
 
-                        comm =
-                            "MERGE INTO " + BulkOperationsHelper.GetFullQualifyingTableName(conn.Database, _schema, _tableName) +
-                            " WITH (HOLDLOCK) AS Target " +
-                            "USING " + Constants.TempTableName + " AS Source " +
-                            BulkOperationsHelper.BuildJoinConditionsForUpdateOrInsert(_matchTargetOn.ToArray(),
-                                Constants.SourceAlias, Constants.TargetAlias) +                            
-                            "WHEN MATCHED " + BulkOperationsHelper.BuildPredicateQuery(_matchTargetOn.ToArray(), _updatePredicates, Constants.TargetAlias) + 
-                            "THEN UPDATE " +
-                            BulkOperationsHelper.BuildUpdateSet(_columns, Constants.SourceAlias, Constants.TargetAlias, _identityColumn) +
-                            "WHEN NOT MATCHED BY TARGET THEN " +
-                            BulkOperationsHelper.BuildInsertSet(_columns, Constants.SourceAlias, _identityColumn) +
-                            (_deleteWhenNotMatchedFlag ? " WHEN NOT MATCHED BY SOURCE " + BulkOperationsHelper.BuildPredicateQuery(_matchTargetOn.ToArray(), 
-                            _deletePredicates, Constants.TargetAlias) + 
-                            "THEN DELETE " : " ") +
-                            BulkOperationsHelper.GetOutputIdentityCmd(_identityColumn, _outputIdentity, Constants.TempOutputTableName,
-                                OperationType.InsertOrUpdate) + "; " +
-                            "DROP TABLE " + Constants.TempTableName + ";";
+				if ( !string.IsNullOrWhiteSpace( comm ) )
+				{
+					command.CommandText = comm;
+					command.ExecuteNonQuery();
+				}
 
-                        command.CommandText = comm;
+				comm =
+					"MERGE INTO " + BulkOperationsHelper.GetFullQualifyingTableName( conn.Database, _schema, _tableName ) +
+					" WITH (HOLDLOCK) AS Target " +
+					"USING " + Constants.TempTableName + " AS Source " +
+					BulkOperationsHelper.BuildJoinConditionsForUpdateOrInsert( _matchTargetOn.ToArray(),
+						Constants.SourceAlias, Constants.TargetAlias ) +
+					"WHEN MATCHED " + BulkOperationsHelper.BuildPredicateQuery( _matchTargetOn.ToArray(), _updatePredicates, Constants.TargetAlias ) +
+					"THEN UPDATE " +
+					BulkOperationsHelper.BuildUpdateSet( _columns, Constants.SourceAlias, Constants.TargetAlias, _identityColumn ) +
+					"WHEN NOT MATCHED BY TARGET THEN " +
+					BulkOperationsHelper.BuildInsertSet( _columns, Constants.SourceAlias, _identityColumn ) +
+					( _deleteWhenNotMatchedFlag ? " WHEN NOT MATCHED BY SOURCE " + BulkOperationsHelper.BuildPredicateQuery( _matchTargetOn.ToArray(),
+					_deletePredicates, Constants.TargetAlias ) +
+					"THEN DELETE " : " " ) +
+					BulkOperationsHelper.GetOutputIdentityCmd( _identityColumn, _outputIdentity, Constants.TempOutputTableName,
+						OperationType.InsertOrUpdate ) + "; " +
+					"DROP TABLE " + Constants.TempTableName + ";";
 
-                        if (_parameters.Count > 0)
-                        {
-                            command.Parameters.AddRange(_parameters.ToArray());
-                        }
+				command.CommandText = comm;
 
-                        affectedRows = command.ExecuteNonQuery();
+				if ( _parameters.Count > 0 )
+				{
+					command.Parameters.AddRange( _parameters.ToArray() );
+				}
 
-                        if (_disableIndexList != null && _disableIndexList.Any())
-                        {
-                            command.CommandText = BulkOperationsHelper.GetIndexManagementCmd(IndexOperation.Rebuild,
-                                _tableName, _schema, conn, _disableIndexList);
-                            command.ExecuteNonQuery();
-                        }
+				affectedRows = command.ExecuteNonQuery();
 
-                        if (_outputIdentity == ColumnDirection.InputOutput)
-                        {
-                            BulkOperationsHelper.LoadFromTmpOutputTable(command, _identityColumn, _outputIdentityDic, OperationType.InsertOrUpdate, _list);
-                        }
+				if ( _disableIndexList != null && _disableIndexList.Any() )
+				{
+					command.CommandText = BulkOperationsHelper.GetIndexManagementCmd( IndexOperation.Rebuild,
+						_tableName, _schema, conn, _disableIndexList );
+					command.ExecuteNonQuery();
+				}
 
-                        transaction.Commit();
-                        return affectedRows;
-                    }
+				if ( _outputIdentity == ColumnDirection.InputOutput )
+				{
+					BulkOperationsHelper.LoadFromTmpOutputTable( command, _identityColumn, _outputIdentityDic, OperationType.InsertOrUpdate, _list );
+				}
 
-                    catch (SqlException e)
-                    {
-                        for (int i = 0; i < e.Errors.Count; i++)
-                        {
-                            // Error 8102 is identity error. 
-                            if (e.Errors[i].Number == 8102)
-                            {
-                                // Expensive but neccessary to inform user of an important configuration setup. 
-                                throw new IdentityException(e.Errors[i].Message);
-                            }
-                        }
+				if ( handleTransactionInternally )
+				{
+					transaction.Commit();
+				}
+				return affectedRows;
+			}
 
-                        transaction.Rollback();
-                        throw;
-                    }
+			catch ( SqlException e )
+			{
+				for ( int i = 0; i < e.Errors.Count; i++ )
+				{
+					// Error 8102 is identity error. 
+					if ( e.Errors[i].Number == 8102 )
+					{
+						// Expensive but neccessary to inform user of an important configuration setup. 
+						throw new IdentityException( e.Errors[i].Message );
+					}
+				}
 
-                    catch (Exception)
-                    {
-                        transaction.Rollback();
-                        throw;
-                    }
-                    finally
-                    {
-                        conn.Close();
-                    }
-                }
-            }
-        }
+				if ( handleTransactionInternally )
+				{
+					transaction.Rollback();
+				}
+				throw;
+			}
 
-        async Task<int> ITransaction.CommitTransactionAsync(string connectionName, SqlCredential credentials, SqlConnection connection)
-        {
-            int affectedRows = 0;
-            if (!_list.Any())
-            {
-                return affectedRows;
-            }
+			catch ( Exception )
+			{
+				if ( handleTransactionInternally )
+				{
+					transaction.Rollback();
+				}
+				throw;
+			}
+			finally
+			{
+				if ( handleTransactionInternally )
+				{
+					transaction.Dispose();
+				}
+				if ( handleConnectionInternally )
+				{
+					conn.Close();
+					conn.Dispose();
+				}
+			}
+		}
 
-            base.IndexCheck();
-            base.MatchTargetCheck();
+		async Task<int> ITransaction.CommitTransactionAsync( string connectionName, SqlCredential credentials, SqlConnection connection, SqlTransaction transaction )
+		{
+			int affectedRows = 0;
+			if ( !_list.Any() )
+			{
+				return affectedRows;
+			}
 
-            DataTable dt = BulkOperationsHelper.CreateDataTable<T>(_columns, _customColumnMappings, _matchTargetOn, _outputIdentity);
-            dt = BulkOperationsHelper.ConvertListToDataTable(dt, _list, _columns, _outputIdentityDic);
+			base.IndexCheck();
+			base.MatchTargetCheck();
 
-            // Must be after ToDataTable is called. 
-            BulkOperationsHelper.DoColumnMappings(_customColumnMappings, _columns, _matchTargetOn);
-            BulkOperationsHelper.DoColumnMappings(_customColumnMappings, _deletePredicates);
-            BulkOperationsHelper.DoColumnMappings(_customColumnMappings, _updatePredicates);
+			DataTable dt = BulkOperationsHelper.CreateDataTable<T>( _columns, _customColumnMappings, _matchTargetOn, _outputIdentity );
+			dt = BulkOperationsHelper.ConvertListToDataTable( dt, _list, _columns, _outputIdentityDic );
 
-            using (SqlConnection conn = BulkOperationsHelper.GetSqlConnection(connectionName, credentials, connection))
-            {
-                await conn.OpenAsync();
-                var dtCols = BulkOperationsHelper.GetDatabaseSchema(conn, _schema, _tableName);
-                using (SqlTransaction transaction = conn.BeginTransaction())
-                {
-                    try
-                    {
-                        SqlCommand command = conn.CreateCommand();
-                        command.Connection = conn;
-                        command.Transaction = transaction;
-                        command.CommandTimeout = _sqlTimeout;
+			// Must be after ToDataTable is called. 
+			BulkOperationsHelper.DoColumnMappings( _customColumnMappings, _columns, _matchTargetOn );
+			BulkOperationsHelper.DoColumnMappings( _customColumnMappings, _deletePredicates );
+			BulkOperationsHelper.DoColumnMappings( _customColumnMappings, _updatePredicates );
 
-                        //Creating temp table on database
-                        command.CommandText = BulkOperationsHelper.BuildCreateTempTable(_columns, dtCols, _outputIdentity);
-                        await command.ExecuteNonQueryAsync();
+			bool handleConnectionInternally = false;
+			SqlConnection conn = BulkOperationsHelper.GetSqlConnection( connectionName, credentials, connection );
+			if ( conn.State != ConnectionState.Open )
+			{
+				await conn.OpenAsync();
+				handleConnectionInternally = true;
+			}
+			var dtCols = BulkOperationsHelper.GetDatabaseSchema( conn, _schema, _tableName );
+			bool handleTransactionInternally = false;
+			if ( transaction == null )
+			{
+				transaction = conn.BeginTransaction();
+				handleConnectionInternally = true;
+			}
+			try
+			{
+				SqlCommand command = conn.CreateCommand();
+				command.Connection = conn;
+				command.Transaction = transaction;
+				command.CommandTimeout = _sqlTimeout;
 
-                        await BulkOperationsHelper.InsertToTmpTableAsync(conn, transaction, dt, _bulkCopyEnableStreaming, _bulkCopyBatchSize,
-                            _bulkCopyNotifyAfter, _bulkCopyTimeout, _sqlBulkCopyOptions, _bulkCopyDelegates);
+				//Creating temp table on database
+				command.CommandText = BulkOperationsHelper.BuildCreateTempTable( _columns, dtCols, _outputIdentity );
+				await command.ExecuteNonQueryAsync();
 
-                        if (_disableIndexList != null && _disableIndexList.Any())
-                        {
-                            command.CommandText = BulkOperationsHelper.GetIndexManagementCmd(IndexOperation.Disable, _tableName, _schema,
-                                conn, _disableIndexList, _disableAllIndexes);
-                            await command.ExecuteNonQueryAsync();
-                        }
+				await BulkOperationsHelper.InsertToTmpTableAsync( conn, transaction, dt, _bulkCopyEnableStreaming, _bulkCopyBatchSize,
+					_bulkCopyNotifyAfter, _bulkCopyTimeout, _sqlBulkCopyOptions, _bulkCopyDelegates );
 
-                        string comm = BulkOperationsHelper.GetOutputCreateTableCmd(_outputIdentity, Constants.TempOutputTableName,
-                        OperationType.InsertOrUpdate, _identityColumn);
+				if ( _disableIndexList != null && _disableIndexList.Any() )
+				{
+					command.CommandText = BulkOperationsHelper.GetIndexManagementCmd( IndexOperation.Disable, _tableName, _schema,
+						conn, _disableIndexList, _disableAllIndexes );
+					await command.ExecuteNonQueryAsync();
+				}
 
-                        if (!string.IsNullOrWhiteSpace(comm))
-                        {
-                            command.CommandText = comm;
-                            command.ExecuteNonQuery();
-                        }
+				string comm = BulkOperationsHelper.GetOutputCreateTableCmd( _outputIdentity, Constants.TempOutputTableName,
+				OperationType.InsertOrUpdate, _identityColumn );
 
-                        // Updating destination table, and dropping temp table                       
-                        comm = "MERGE INTO " + BulkOperationsHelper.GetFullQualifyingTableName(conn.Database, _schema, _tableName) + " WITH (HOLDLOCK) AS Target " +
-                                      "USING " + Constants.TempTableName + " AS Source " +
-                                      BulkOperationsHelper.BuildJoinConditionsForUpdateOrInsert(_matchTargetOn.ToArray(),
-                                          Constants.SourceAlias, Constants.TargetAlias) +
-                                      "WHEN MATCHED " + BulkOperationsHelper.BuildPredicateQuery(_matchTargetOn.ToArray(), _updatePredicates, Constants.TargetAlias) +
-                                      "THEN UPDATE " +
-                                      BulkOperationsHelper.BuildUpdateSet(_columns, Constants.SourceAlias, Constants.TargetAlias, _identityColumn) +
-                                      "WHEN NOT MATCHED BY TARGET THEN " +
-                                      BulkOperationsHelper.BuildInsertSet(_columns, Constants.SourceAlias, _identityColumn) +
-                                      (_deleteWhenNotMatchedFlag ? " WHEN NOT MATCHED BY SOURCE " + BulkOperationsHelper.BuildPredicateQuery(_matchTargetOn.ToArray(), 
-                                      _deletePredicates, Constants.TargetAlias) +
-                                      "THEN DELETE " : " ") +
-                                       BulkOperationsHelper.GetOutputIdentityCmd(_identityColumn, _outputIdentity, Constants.TempOutputTableName,
-                                       OperationType.InsertOrUpdate) + "; " +
-                                       "DROP TABLE " + Constants.TempTableName + ";";
-                        command.CommandText = comm;
+				if ( !string.IsNullOrWhiteSpace( comm ) )
+				{
+					command.CommandText = comm;
+					command.ExecuteNonQuery();
+				}
 
-                        if (_parameters.Count > 0)
-                        {
-                            command.Parameters.AddRange(_parameters.ToArray());
-                        }
+				// Updating destination table, and dropping temp table                       
+				comm = "MERGE INTO " + BulkOperationsHelper.GetFullQualifyingTableName( conn.Database, _schema, _tableName ) + " WITH (HOLDLOCK) AS Target " +
+							  "USING " + Constants.TempTableName + " AS Source " +
+							  BulkOperationsHelper.BuildJoinConditionsForUpdateOrInsert( _matchTargetOn.ToArray(),
+								  Constants.SourceAlias, Constants.TargetAlias ) +
+							  "WHEN MATCHED " + BulkOperationsHelper.BuildPredicateQuery( _matchTargetOn.ToArray(), _updatePredicates, Constants.TargetAlias ) +
+							  "THEN UPDATE " +
+							  BulkOperationsHelper.BuildUpdateSet( _columns, Constants.SourceAlias, Constants.TargetAlias, _identityColumn ) +
+							  "WHEN NOT MATCHED BY TARGET THEN " +
+							  BulkOperationsHelper.BuildInsertSet( _columns, Constants.SourceAlias, _identityColumn ) +
+							  ( _deleteWhenNotMatchedFlag ? " WHEN NOT MATCHED BY SOURCE " + BulkOperationsHelper.BuildPredicateQuery( _matchTargetOn.ToArray(),
+							  _deletePredicates, Constants.TargetAlias ) +
+							  "THEN DELETE " : " " ) +
+							   BulkOperationsHelper.GetOutputIdentityCmd( _identityColumn, _outputIdentity, Constants.TempOutputTableName,
+							   OperationType.InsertOrUpdate ) + "; " +
+							   "DROP TABLE " + Constants.TempTableName + ";";
+				command.CommandText = comm;
 
-                        affectedRows = await command.ExecuteNonQueryAsync();
+				if ( _parameters.Count > 0 )
+				{
+					command.Parameters.AddRange( _parameters.ToArray() );
+				}
 
-                        if (_disableIndexList != null && _disableIndexList.Any())
-                        {
-                            command.CommandText = BulkOperationsHelper.GetIndexManagementCmd(IndexOperation.Rebuild, _tableName,
-                                _schema, conn, _disableIndexList);
-                            await command.ExecuteNonQueryAsync();
-                        }
+				affectedRows = await command.ExecuteNonQueryAsync();
 
-                        if (_outputIdentity == ColumnDirection.InputOutput)
-                        {
-                            await
-                                BulkOperationsHelper.LoadFromTmpOutputTableAsync(command, _identityColumn, _outputIdentityDic,
-                                    OperationType.InsertOrUpdate, _list);
+				if ( _disableIndexList != null && _disableIndexList.Any() )
+				{
+					command.CommandText = BulkOperationsHelper.GetIndexManagementCmd( IndexOperation.Rebuild, _tableName,
+						_schema, conn, _disableIndexList );
+					await command.ExecuteNonQueryAsync();
+				}
 
-                        }
+				if ( _outputIdentity == ColumnDirection.InputOutput )
+				{
+					await
+						BulkOperationsHelper.LoadFromTmpOutputTableAsync( command, _identityColumn, _outputIdentityDic,
+							OperationType.InsertOrUpdate, _list );
 
-                        transaction.Commit();
-                        return affectedRows;
-                    }
+				}
 
-                    catch (SqlException e)
-                    {
-                        for (int i = 0; i < e.Errors.Count; i++)
-                        {
-                            // Error 8102 is identity error. 
-                            if (e.Errors[i].Number == 8102)
-                            {
-                                // Expensive call but neccessary to inform user of an important configuration setup. 
-                                throw new IdentityException(e.Errors[i].Message);
-                            }
-                        }
+				if ( handleTransactionInternally )
+				{
+					transaction.Commit();
+				}
+				return affectedRows;
+			}
 
-                        transaction.Rollback();
-                        throw;
-                    }
+			catch ( SqlException e )
+			{
+				for ( int i = 0; i < e.Errors.Count; i++ )
+				{
+					// Error 8102 is identity error. 
+					if ( e.Errors[i].Number == 8102 )
+					{
+						// Expensive call but neccessary to inform user of an important configuration setup. 
+						throw new IdentityException( e.Errors[i].Message );
+					}
+				}
+				if ( handleTransactionInternally )
+				{
+					transaction.Rollback();
+				}
+				throw;
+			}
 
-                    catch (Exception)
-                    {
-                        transaction.Rollback();
-                        throw;
-                    }
-                    finally
-                    {
-                        conn.Close();
-                    }
-                }
-            }
-        }
-    }
+			catch ( Exception )
+			{
+				if ( handleTransactionInternally )
+				{
+					transaction.Rollback();
+				}
+				throw;
+			}
+			finally
+			{
+				if ( handleConnectionInternally )
+				{
+					transaction.Dispose();
+				}
+				if ( handleConnectionInternally )
+				{
+					conn.Close();
+					conn.Dispose();
+				}
+			}
+		}
+	}
 }

--- a/SqlBulkTools/BulkOperations/BulkCopy/BulkInsertOrUpdate.cs
+++ b/SqlBulkTools/BulkOperations/BulkCopy/BulkInsertOrUpdate.cs
@@ -165,7 +165,7 @@ namespace SqlBulkTools
 				conn.Open();
 				handleConnectionInternally = true;
 			}
-			var dtCols = BulkOperationsHelper.GetDatabaseSchema( conn, _schema, _tableName );
+			var dtCols = BulkOperationsHelper.GetDatabaseSchema( conn, _schema, _tableName, transaction );
 
 			bool handleTransactionInternally = false;
 			if ( transaction == null )
@@ -319,7 +319,7 @@ namespace SqlBulkTools
 				await conn.OpenAsync();
 				handleConnectionInternally = true;
 			}
-			var dtCols = BulkOperationsHelper.GetDatabaseSchema( conn, _schema, _tableName );
+			var dtCols = BulkOperationsHelper.GetDatabaseSchema( conn, _schema, _tableName, transaction );
 			bool handleTransactionInternally = false;
 			if ( transaction == null )
 			{

--- a/SqlBulkTools/BulkOperations/BulkCopy/BulkUpdate.cs
+++ b/SqlBulkTools/BulkOperations/BulkCopy/BulkUpdate.cs
@@ -9,346 +9,393 @@ using System.Threading.Tasks;
 // ReSharper disable once CheckNamespace
 namespace SqlBulkTools
 {
-    /// <summary>
-    /// 
-    /// </summary>
-    /// <typeparam name="T"></typeparam>
-    public class BulkUpdate<T> : AbstractOperation<T>, ITransaction
-    {
-        /// <summary>
-        /// Updates existing records in bulk. 
-        /// </summary>
-        /// <param name="list"></param>
-        /// <param name="tableName"></param>
-        /// <param name="schema"></param>
-        /// <param name="columns"></param>
-        /// <param name="disableAllIndexes"></param>
-        /// <param name="customColumnMappings"></param>
-        /// <param name="sqlTimeout"></param>
-        /// <param name="bulkCopyTimeout"></param>
-        /// <param name="bulkCopyEnableStreaming"></param>
-        /// <param name="bulkCopyNotifyAfter"></param>
-        /// <param name="bulkCopyBatchSize"></param>
-        /// <param name="sqlBulkCopyOptions"></param>
-        /// <param name="ext"></param>
-        /// <param name="disableIndexList"></param>
-        /// <param name="bulkCopyDelegates"></param>
-        public BulkUpdate(IEnumerable<T> list, string tableName, string schema, HashSet<string> columns, HashSet<string> disableIndexList, 
-            bool disableAllIndexes, Dictionary<string, string> customColumnMappings, int sqlTimeout, int bulkCopyTimeout, 
-            bool bulkCopyEnableStreaming, int? bulkCopyNotifyAfter, int? bulkCopyBatchSize, SqlBulkCopyOptions sqlBulkCopyOptions, 
-            BulkOperations ext, IEnumerable<SqlRowsCopiedEventHandler> bulkCopyDelegates) 
-            :
-            base(list, tableName, schema, columns, disableIndexList, disableAllIndexes, customColumnMappings, sqlTimeout,
-                bulkCopyTimeout, bulkCopyEnableStreaming, bulkCopyNotifyAfter, bulkCopyBatchSize, sqlBulkCopyOptions, ext, bulkCopyDelegates)
-        {
-            _ext.SetBulkExt(this);
-            _updatePredicates = new List<Condition>();
-            _parameters = new List<SqlParameter>();
-            _conditionSortOrder = 1;
-        }
+	/// <summary>
+	/// 
+	/// </summary>
+	/// <typeparam name="T"></typeparam>
+	public class BulkUpdate<T> : AbstractOperation<T>, ITransaction
+	{
+		/// <summary>
+		/// Updates existing records in bulk. 
+		/// </summary>
+		/// <param name="list"></param>
+		/// <param name="tableName"></param>
+		/// <param name="schema"></param>
+		/// <param name="columns"></param>
+		/// <param name="disableAllIndexes"></param>
+		/// <param name="customColumnMappings"></param>
+		/// <param name="sqlTimeout"></param>
+		/// <param name="bulkCopyTimeout"></param>
+		/// <param name="bulkCopyEnableStreaming"></param>
+		/// <param name="bulkCopyNotifyAfter"></param>
+		/// <param name="bulkCopyBatchSize"></param>
+		/// <param name="sqlBulkCopyOptions"></param>
+		/// <param name="ext"></param>
+		/// <param name="disableIndexList"></param>
+		/// <param name="bulkCopyDelegates"></param>
+		public BulkUpdate( IEnumerable<T> list, string tableName, string schema, HashSet<string> columns, HashSet<string> disableIndexList,
+			bool disableAllIndexes, Dictionary<string, string> customColumnMappings, int sqlTimeout, int bulkCopyTimeout,
+			bool bulkCopyEnableStreaming, int? bulkCopyNotifyAfter, int? bulkCopyBatchSize, SqlBulkCopyOptions sqlBulkCopyOptions,
+			BulkOperations ext, IEnumerable<SqlRowsCopiedEventHandler> bulkCopyDelegates )
+			:
+			base( list, tableName, schema, columns, disableIndexList, disableAllIndexes, customColumnMappings, sqlTimeout,
+				bulkCopyTimeout, bulkCopyEnableStreaming, bulkCopyNotifyAfter, bulkCopyBatchSize, sqlBulkCopyOptions, ext, bulkCopyDelegates )
+		{
+			_ext.SetBulkExt( this );
+			_updatePredicates = new List<Condition>();
+			_parameters = new List<SqlParameter>();
+			_conditionSortOrder = 1;
+		}
 
-        /// <summary>
-        /// Only update records when the target satisfies a speicific requirement. This is used in conjunction with MatchTargetOn.
-        /// See help docs for examples.  
-        /// </summary>
-        /// <param name="predicate"></param>
-        /// <returns></returns>
-        /// <exception cref="SqlBulkToolsException"></exception>
-        public BulkUpdate<T> UpdateWhen(Expression<Func<T, bool>> predicate)
-        {
-            BulkOperationsHelper.AddPredicate(predicate, PredicateType.Update, _updatePredicates, _parameters, _conditionSortOrder, Constants.UniqueParamIdentifier);
-            _conditionSortOrder++;
+		/// <summary>
+		/// Only update records when the target satisfies a speicific requirement. This is used in conjunction with MatchTargetOn.
+		/// See help docs for examples.  
+		/// </summary>
+		/// <param name="predicate"></param>
+		/// <returns></returns>
+		/// <exception cref="SqlBulkToolsException"></exception>
+		public BulkUpdate<T> UpdateWhen( Expression<Func<T, bool>> predicate )
+		{
+			BulkOperationsHelper.AddPredicate( predicate, PredicateType.Update, _updatePredicates, _parameters, _conditionSortOrder, Constants.UniqueParamIdentifier );
+			_conditionSortOrder++;
 
-            return this;
-        }
+			return this;
+		}
 
-        /// <summary>
-        /// At least one MatchTargetOn is required for correct configuration. MatchTargetOn is the matching clause for evaluating 
-        /// each row in table. This is usally set to the unique identifier in the table (e.g. Id). Multiple MatchTargetOn members are allowed 
-        /// for matching composite relationships. 
-        /// </summary>
-        /// <param name="columnName"></param>
-        /// <returns></returns>
-        public BulkUpdate<T> MatchTargetOn(Expression<Func<T, object>> columnName)
-        {
-            var propertyName = BulkOperationsHelper.GetPropertyName(columnName);
+		/// <summary>
+		/// At least one MatchTargetOn is required for correct configuration. MatchTargetOn is the matching clause for evaluating 
+		/// each row in table. This is usally set to the unique identifier in the table (e.g. Id). Multiple MatchTargetOn members are allowed 
+		/// for matching composite relationships. 
+		/// </summary>
+		/// <param name="columnName"></param>
+		/// <returns></returns>
+		public BulkUpdate<T> MatchTargetOn( Expression<Func<T, object>> columnName )
+		{
+			var propertyName = BulkOperationsHelper.GetPropertyName( columnName );
 
-            if (propertyName == null)
-                throw new SqlBulkToolsException("MatchTargetOn column name can't be null.");
+			if ( propertyName == null )
+				throw new SqlBulkToolsException( "MatchTargetOn column name can't be null." );
 
-            _matchTargetOn.Add(propertyName);
+			_matchTargetOn.Add( propertyName );
 
-            return this;
-        }
+			return this;
+		}
 
-        /// <summary>
-        /// Sets the identity column for the table. Required if an Identity column exists in table and one of the two 
-        /// following conditions is met: (1) MatchTargetOn list contains an identity column (2) AddAllColumns is used in setup. 
-        /// </summary>
-        /// <param name="columnName"></param>
-        /// <returns></returns>
-        public BulkUpdate<T> SetIdentityColumn(Expression<Func<T, object>> columnName)
-        {
-            base.SetIdentity(columnName);
-            return this;
-        }
+		/// <summary>
+		/// Sets the identity column for the table. Required if an Identity column exists in table and one of the two 
+		/// following conditions is met: (1) MatchTargetOn list contains an identity column (2) AddAllColumns is used in setup. 
+		/// </summary>
+		/// <param name="columnName"></param>
+		/// <returns></returns>
+		public BulkUpdate<T> SetIdentityColumn( Expression<Func<T, object>> columnName )
+		{
+			base.SetIdentity( columnName );
+			return this;
+		}
 
-        /// <summary>
-        /// Sets the identity column for the table. Required if an Identity column exists in table and one of the two 
-        /// following conditions is met: (1) MatchTargetOn list contains an identity column (2) AddAllColumns is used in setup. 
-        /// </summary>
-        /// <param name="columnName"></param>
-        /// <param name="outputIdentity"></param>
-        /// <returns></returns>
-        public BulkUpdate<T> SetIdentityColumn(Expression<Func<T, object>> columnName, ColumnDirection outputIdentity)
-        {
-            base.SetIdentity(columnName, outputIdentity);
-            return this;
-        }
+		/// <summary>
+		/// Sets the identity column for the table. Required if an Identity column exists in table and one of the two 
+		/// following conditions is met: (1) MatchTargetOn list contains an identity column (2) AddAllColumns is used in setup. 
+		/// </summary>
+		/// <param name="columnName"></param>
+		/// <param name="outputIdentity"></param>
+		/// <returns></returns>
+		public BulkUpdate<T> SetIdentityColumn( Expression<Func<T, object>> columnName, ColumnDirection outputIdentity )
+		{
+			base.SetIdentity( columnName, outputIdentity );
+			return this;
+		}
 
-        int ITransaction.CommitTransaction(string connectionName, SqlCredential credentials, SqlConnection connection)
-        {
-            int affectedRows = 0;
-            if (!_list.Any())
-            {
-                return affectedRows;
-            }
+		int ITransaction.CommitTransaction( string connectionName, SqlCredential credentials, SqlConnection connection, SqlTransaction transaction )
+		{
+			int affectedRows = 0;
+			if ( !_list.Any() )
+			{
+				return affectedRows;
+			}
 
-            base.IndexCheck();
-            base.MatchTargetCheck();
+			base.IndexCheck();
+			base.MatchTargetCheck();
 
-            DataTable dt = BulkOperationsHelper.CreateDataTable<T>(_columns, _customColumnMappings, _matchTargetOn, _outputIdentity);
-            dt = BulkOperationsHelper.ConvertListToDataTable(dt, _list, _columns, _outputIdentityDic);
+			DataTable dt = BulkOperationsHelper.CreateDataTable<T>( _columns, _customColumnMappings, _matchTargetOn, _outputIdentity );
+			dt = BulkOperationsHelper.ConvertListToDataTable( dt, _list, _columns, _outputIdentityDic );
 
-            // Must be after ToDataTable is called. 
-            BulkOperationsHelper.DoColumnMappings(_customColumnMappings, _columns, _matchTargetOn);
-            BulkOperationsHelper.DoColumnMappings(_customColumnMappings, _updatePredicates);
+			// Must be after ToDataTable is called. 
+			BulkOperationsHelper.DoColumnMappings( _customColumnMappings, _columns, _matchTargetOn );
+			BulkOperationsHelper.DoColumnMappings( _customColumnMappings, _updatePredicates );
 
-            using (SqlConnection conn = BulkOperationsHelper.GetSqlConnection(connectionName, credentials, connection))
-            {
-                conn.Open();
-                var dtCols = BulkOperationsHelper.GetDatabaseSchema(conn, _schema, _tableName);
+			bool handleConnectionInternally = false;
+			SqlConnection conn = BulkOperationsHelper.GetSqlConnection( connectionName, credentials, connection );
+			if ( conn.State != ConnectionState.Open )
+			{
+				conn.Open();
+				handleConnectionInternally = true;
+			}
+			var dtCols = BulkOperationsHelper.GetDatabaseSchema( conn, _schema, _tableName, transaction );
 
-                using (SqlTransaction transaction = conn.BeginTransaction())
-                {
-                    try
-                    {
-                        SqlCommand command = conn.CreateCommand();
-                        command.Connection = conn;
-                        command.Transaction = transaction;
-                        command.CommandTimeout = _sqlTimeout;
+			bool handleTransactionInternally = false;
+			if ( transaction == null )
+			{
+				transaction = conn.BeginTransaction();
+				handleTransactionInternally = true;
+			}
+			try
+			{
+				SqlCommand command = conn.CreateCommand();
+				command.Connection = conn;
+				command.Transaction = transaction;
+				command.CommandTimeout = _sqlTimeout;
 
-                        //Creating temp table on database
-                        command.CommandText = BulkOperationsHelper.BuildCreateTempTable(_columns, dtCols, _outputIdentity);
-                        command.ExecuteNonQuery();
+				//Creating temp table on database
+				command.CommandText = BulkOperationsHelper.BuildCreateTempTable( _columns, dtCols, _outputIdentity );
+				command.ExecuteNonQuery();
 
-                        //Bulk insert into temp table
-                        BulkOperationsHelper.InsertToTmpTable(conn, transaction, dt, _bulkCopyEnableStreaming, _bulkCopyBatchSize,
-                            _bulkCopyNotifyAfter, _bulkCopyTimeout, _sqlBulkCopyOptions, _bulkCopyDelegates);
+				//Bulk insert into temp table
+				BulkOperationsHelper.InsertToTmpTable( conn, transaction, dt, _bulkCopyEnableStreaming, _bulkCopyBatchSize,
+					_bulkCopyNotifyAfter, _bulkCopyTimeout, _sqlBulkCopyOptions, _bulkCopyDelegates );
 
-                        // Updating destination table, and dropping temp table
-                        if (_disableIndexList != null && _disableIndexList.Any())
-                        {
-                            command.CommandText = BulkOperationsHelper.GetIndexManagementCmd(IndexOperation.Disable, _tableName,
-                                _schema, conn, _disableIndexList, _disableAllIndexes);
-                            command.ExecuteNonQuery();
-                        }
+				// Updating destination table, and dropping temp table
+				if ( _disableIndexList != null && _disableIndexList.Any() )
+				{
+					command.CommandText = BulkOperationsHelper.GetIndexManagementCmd( IndexOperation.Disable, _tableName,
+						_schema, conn, _disableIndexList, _disableAllIndexes );
+					command.ExecuteNonQuery();
+				}
 
-                        string comm = BulkOperationsHelper.GetOutputCreateTableCmd(_outputIdentity, Constants.TempOutputTableName,
-                        OperationType.InsertOrUpdate, _identityColumn);
+				string comm = BulkOperationsHelper.GetOutputCreateTableCmd( _outputIdentity, Constants.TempOutputTableName,
+				OperationType.InsertOrUpdate, _identityColumn );
 
-                        if (!string.IsNullOrWhiteSpace(comm))
-                        {
-                            command.CommandText = comm;
-                            command.ExecuteNonQuery();
-                        }
+				if ( !string.IsNullOrWhiteSpace( comm ) )
+				{
+					command.CommandText = comm;
+					command.ExecuteNonQuery();
+				}
 
-                        comm = "MERGE INTO " + BulkOperationsHelper.GetFullQualifyingTableName(conn.Database, _schema, _tableName) + " WITH (HOLDLOCK) AS Target " +
-                                      "USING " + Constants.TempTableName + " AS Source " +
-                                      BulkOperationsHelper.BuildJoinConditionsForUpdateOrInsert(_matchTargetOn.ToArray(),
-                                          Constants.SourceAlias, Constants.TargetAlias) +
-                                      "WHEN MATCHED " + BulkOperationsHelper.BuildPredicateQuery(_matchTargetOn.ToArray(), _updatePredicates, Constants.TargetAlias) +
-                                      "THEN UPDATE " +
-                                      BulkOperationsHelper.BuildUpdateSet(_columns, Constants.SourceAlias, Constants.TargetAlias, _identityColumn) +
-                                      BulkOperationsHelper.GetOutputIdentityCmd(_identityColumn, _outputIdentity, Constants.TempOutputTableName,
-                                OperationType.Update) + "; " +
-                                      "DROP TABLE " + Constants.TempTableName + ";";
-                        command.CommandText = comm;
+				comm = "MERGE INTO " + BulkOperationsHelper.GetFullQualifyingTableName( conn.Database, _schema, _tableName ) + " WITH (HOLDLOCK) AS Target " +
+							  "USING " + Constants.TempTableName + " AS Source " +
+							  BulkOperationsHelper.BuildJoinConditionsForUpdateOrInsert( _matchTargetOn.ToArray(),
+								  Constants.SourceAlias, Constants.TargetAlias ) +
+							  "WHEN MATCHED " + BulkOperationsHelper.BuildPredicateQuery( _matchTargetOn.ToArray(), _updatePredicates, Constants.TargetAlias ) +
+							  "THEN UPDATE " +
+							  BulkOperationsHelper.BuildUpdateSet( _columns, Constants.SourceAlias, Constants.TargetAlias, _identityColumn ) +
+							  BulkOperationsHelper.GetOutputIdentityCmd( _identityColumn, _outputIdentity, Constants.TempOutputTableName,
+						OperationType.Update ) + "; " +
+							  "DROP TABLE " + Constants.TempTableName + ";";
+				command.CommandText = comm;
 
-                        if (_parameters.Count > 0)
-                        {
-                            command.Parameters.AddRange(_parameters.ToArray());
-                        }
+				if ( _parameters.Count > 0 )
+				{
+					command.Parameters.AddRange( _parameters.ToArray() );
+				}
 
-                        affectedRows = command.ExecuteNonQuery();
+				affectedRows = command.ExecuteNonQuery();
 
-                        if (_disableIndexList != null && _disableIndexList.Any())
-                        {
-                            command.CommandText = BulkOperationsHelper.GetIndexManagementCmd(IndexOperation.Rebuild, _tableName, _schema,
-                                conn, _disableIndexList);
-                            command.ExecuteNonQuery();
-                        }
+				if ( _disableIndexList != null && _disableIndexList.Any() )
+				{
+					command.CommandText = BulkOperationsHelper.GetIndexManagementCmd( IndexOperation.Rebuild, _tableName, _schema,
+						conn, _disableIndexList );
+					command.ExecuteNonQuery();
+				}
 
-                        if (_outputIdentity == ColumnDirection.InputOutput)
-                        {
-                            BulkOperationsHelper.LoadFromTmpOutputTable(command, _identityColumn, _outputIdentityDic, OperationType.InsertOrUpdate, _list);
-                        }
+				if ( _outputIdentity == ColumnDirection.InputOutput )
+				{
+					BulkOperationsHelper.LoadFromTmpOutputTable( command, _identityColumn, _outputIdentityDic, OperationType.InsertOrUpdate, _list );
+				}
 
-                        transaction.Commit();
-                        return affectedRows;
-                    }
-
-
-                    catch (SqlException e)
-                    {
-                        for (int i = 0; i < e.Errors.Count; i++)
-                        {
-                            // Error 8102 is identity error. 
-                            if (e.Errors[i].Number == 8102)
-                            {
-                                // Expensive call but neccessary to inform user of an important configuration setup. 
-                                throw new IdentityException(e.Errors[i].Message);
-                            }
-                        }
-                        transaction.Rollback();
-                        throw;
-                    }
-
-                    catch (Exception)
-                    {
-                        transaction.Rollback();
-                        throw;
-                    }
-
-                    finally
-                    {
-                        conn.Close();
-                    }
-                }
-            }
-        }
-
-        async Task<int> ITransaction.CommitTransactionAsync(string connectionName, SqlCredential credentials, SqlConnection connection)
-        {
-            int affectedRows = 0;
-            if (!_list.Any())
-            {
-                return affectedRows;
-            }
-
-            base.IndexCheck();
-            base.MatchTargetCheck();
-
-            DataTable dt = BulkOperationsHelper.CreateDataTable<T>(_columns, _customColumnMappings, _matchTargetOn, _outputIdentity);
-            dt = BulkOperationsHelper.ConvertListToDataTable(dt, _list, _columns, _outputIdentityDic);
-
-            // Must be after ToDataTable is called. 
-            BulkOperationsHelper.DoColumnMappings(_customColumnMappings, _columns, _matchTargetOn);
-            BulkOperationsHelper.DoColumnMappings(_customColumnMappings, _updatePredicates);
-
-            using (SqlConnection conn = BulkOperationsHelper.GetSqlConnection(connectionName, credentials, connection))
-            {
-                await conn.OpenAsync();
-                var dtCols = BulkOperationsHelper.GetDatabaseSchema(conn, _schema, _tableName);
-
-                using (SqlTransaction transaction = conn.BeginTransaction())
-                {
-                    try
-                    {
-                        SqlCommand command = conn.CreateCommand();
-                        command.Connection = conn;
-                        command.Transaction = transaction;
-                        command.CommandTimeout = _sqlTimeout;
-
-                        //Creating temp table on database
-                        command.CommandText = BulkOperationsHelper.BuildCreateTempTable(_columns, dtCols, _outputIdentity);
-                        await command.ExecuteNonQueryAsync();
-
-                        //Bulk insert into temp table
-                        await BulkOperationsHelper.InsertToTmpTableAsync(conn, transaction, dt, _bulkCopyEnableStreaming, _bulkCopyBatchSize,
-                            _bulkCopyNotifyAfter, _bulkCopyTimeout, _sqlBulkCopyOptions, _bulkCopyDelegates);
-
-                        if (_disableIndexList != null && _disableIndexList.Any())
-                        {
-                            command.CommandText = BulkOperationsHelper.GetIndexManagementCmd(IndexOperation.Disable, _tableName,
-                                _schema, conn, _disableIndexList, _disableAllIndexes);
-                            await command.ExecuteNonQueryAsync();
-                        }
-
-                        string comm = BulkOperationsHelper.GetOutputCreateTableCmd(_outputIdentity, Constants.TempOutputTableName,
-                        OperationType.InsertOrUpdate, _identityColumn);
-
-                        if (!string.IsNullOrWhiteSpace(comm))
-                        {
-                            command.CommandText = comm;
-                            command.ExecuteNonQuery();
-                        }
-
-                        // Updating destination table, and dropping temp table
-                        comm = "MERGE INTO " + BulkOperationsHelper.GetFullQualifyingTableName(conn.Database, _schema, _tableName) + " WITH (HOLDLOCK) AS Target " +
-                                      "USING " + Constants.TempTableName + " AS Source " +
-                                      BulkOperationsHelper.BuildJoinConditionsForUpdateOrInsert(_matchTargetOn.ToArray(), Constants.SourceAlias, Constants.TargetAlias) +
-                                      "WHEN MATCHED " + BulkOperationsHelper.BuildPredicateQuery(_matchTargetOn.ToArray(), _updatePredicates, Constants.TargetAlias) +
-                                      "THEN UPDATE " +
-                                      BulkOperationsHelper.BuildUpdateSet(_columns, Constants.SourceAlias, Constants.TargetAlias, _identityColumn) +
-                                      BulkOperationsHelper.GetOutputIdentityCmd(_identityColumn, _outputIdentity, Constants.TempOutputTableName,
-                                      OperationType.Update) + "; " +
-                                      "DROP TABLE " + Constants.TempTableName + ";";
-
-                        command.CommandText = comm;
-
-                        if (_parameters.Count > 0)
-                        {
-                            command.Parameters.AddRange(_parameters.ToArray());
-                        }
-
-                        affectedRows = await command.ExecuteNonQueryAsync();
-
-                        if (_disableIndexList != null && _disableIndexList.Any())
-                        {
-                            command.CommandText = BulkOperationsHelper.GetIndexManagementCmd(IndexOperation.Rebuild, _tableName,
-                                _schema, conn, _disableIndexList);
-                            await command.ExecuteNonQueryAsync();
-                        }
-
-                        if (_outputIdentity == ColumnDirection.InputOutput)
-                        {
-                            await
-                                BulkOperationsHelper.LoadFromTmpOutputTableAsync(command, _identityColumn, _outputIdentityDic,
-                                OperationType.Delete, _list);
-                        }
-
-                        transaction.Commit();
-                        return affectedRows;
-                    }
+				if ( handleTransactionInternally )
+				{
+					transaction.Commit();
+				}
+				return affectedRows;
+			}
 
 
-                    catch (SqlException e)
-                    {
-                        for (int i = 0; i < e.Errors.Count; i++)
-                        {
-                            // Error 8102 is identity error. 
-                            if (e.Errors[i].Number == 8102)
-                            {
-                                // Expensive but neccessary to inform user of an important configuration setup. 
-                                throw new IdentityException(e.Errors[i].Message);
-                            }
-                        }
-                        transaction.Rollback();
-                        throw;
-                    }
+			catch ( SqlException e )
+			{
+				for ( int i = 0; i < e.Errors.Count; i++ )
+				{
+					// Error 8102 is identity error. 
+					if ( e.Errors[i].Number == 8102 )
+					{
+						// Expensive call but neccessary to inform user of an important configuration setup. 
+						throw new IdentityException( e.Errors[i].Message );
+					}
+				}
 
-                    catch (Exception)
-                    {
-                        transaction.Rollback();
-                        throw;
-                    }
-                    finally
-                    {
-                        conn.Close();
-                    }
-                }
-            }
-        }
-    }
+				if ( handleTransactionInternally )
+				{
+					transaction.Rollback();
+				}
+				throw;
+			}
+
+			catch ( Exception )
+			{
+				if ( handleTransactionInternally )
+				{
+					transaction.Rollback();
+				}
+				throw;
+			}
+
+			finally
+			{
+				if ( handleTransactionInternally )
+				{
+					transaction.Dispose();
+				}
+				if ( handleConnectionInternally )
+				{
+					conn.Close();
+					conn.Dispose();
+				}
+			}
+		}
+
+		async Task<int> ITransaction.CommitTransactionAsync( string connectionName, SqlCredential credentials, SqlConnection connection, SqlTransaction transaction )
+		{
+			int affectedRows = 0;
+			if ( !_list.Any() )
+			{
+				return affectedRows;
+			}
+
+			base.IndexCheck();
+			base.MatchTargetCheck();
+
+			DataTable dt = BulkOperationsHelper.CreateDataTable<T>( _columns, _customColumnMappings, _matchTargetOn, _outputIdentity );
+			dt = BulkOperationsHelper.ConvertListToDataTable( dt, _list, _columns, _outputIdentityDic );
+
+			// Must be after ToDataTable is called. 
+			BulkOperationsHelper.DoColumnMappings( _customColumnMappings, _columns, _matchTargetOn );
+			BulkOperationsHelper.DoColumnMappings( _customColumnMappings, _updatePredicates );
+
+			bool handleConnectionInternally = false;
+			SqlConnection conn = BulkOperationsHelper.GetSqlConnection( connectionName, credentials, connection );
+			if ( conn.State != ConnectionState.Open )
+			{
+				await conn.OpenAsync();
+				handleConnectionInternally = true;
+			}
+			var dtCols = BulkOperationsHelper.GetDatabaseSchema( conn, _schema, _tableName, transaction );
+
+			bool handleTransactionInternally = false;
+			if ( transaction == null )
+			{
+				transaction = conn.BeginTransaction();
+				handleTransactionInternally = true;
+			}
+			try
+			{
+				SqlCommand command = conn.CreateCommand();
+				command.Connection = conn;
+				command.Transaction = transaction;
+				command.CommandTimeout = _sqlTimeout;
+
+				//Creating temp table on database
+				command.CommandText = BulkOperationsHelper.BuildCreateTempTable( _columns, dtCols, _outputIdentity );
+				await command.ExecuteNonQueryAsync();
+
+				//Bulk insert into temp table
+				await BulkOperationsHelper.InsertToTmpTableAsync( conn, transaction, dt, _bulkCopyEnableStreaming, _bulkCopyBatchSize,
+					_bulkCopyNotifyAfter, _bulkCopyTimeout, _sqlBulkCopyOptions, _bulkCopyDelegates );
+
+				if ( _disableIndexList != null && _disableIndexList.Any() )
+				{
+					command.CommandText = BulkOperationsHelper.GetIndexManagementCmd( IndexOperation.Disable, _tableName,
+						_schema, conn, _disableIndexList, _disableAllIndexes );
+					await command.ExecuteNonQueryAsync();
+				}
+
+				string comm = BulkOperationsHelper.GetOutputCreateTableCmd( _outputIdentity, Constants.TempOutputTableName,
+				OperationType.InsertOrUpdate, _identityColumn );
+
+				if ( !string.IsNullOrWhiteSpace( comm ) )
+				{
+					command.CommandText = comm;
+					command.ExecuteNonQuery();
+				}
+
+				// Updating destination table, and dropping temp table
+				comm = "MERGE INTO " + BulkOperationsHelper.GetFullQualifyingTableName( conn.Database, _schema, _tableName ) + " WITH (HOLDLOCK) AS Target " +
+							  "USING " + Constants.TempTableName + " AS Source " +
+							  BulkOperationsHelper.BuildJoinConditionsForUpdateOrInsert( _matchTargetOn.ToArray(), Constants.SourceAlias, Constants.TargetAlias ) +
+							  "WHEN MATCHED " + BulkOperationsHelper.BuildPredicateQuery( _matchTargetOn.ToArray(), _updatePredicates, Constants.TargetAlias ) +
+							  "THEN UPDATE " +
+							  BulkOperationsHelper.BuildUpdateSet( _columns, Constants.SourceAlias, Constants.TargetAlias, _identityColumn ) +
+							  BulkOperationsHelper.GetOutputIdentityCmd( _identityColumn, _outputIdentity, Constants.TempOutputTableName,
+							  OperationType.Update ) + "; " +
+							  "DROP TABLE " + Constants.TempTableName + ";";
+
+				command.CommandText = comm;
+
+				if ( _parameters.Count > 0 )
+				{
+					command.Parameters.AddRange( _parameters.ToArray() );
+				}
+
+				affectedRows = await command.ExecuteNonQueryAsync();
+
+				if ( _disableIndexList != null && _disableIndexList.Any() )
+				{
+					command.CommandText = BulkOperationsHelper.GetIndexManagementCmd( IndexOperation.Rebuild, _tableName,
+						_schema, conn, _disableIndexList );
+					await command.ExecuteNonQueryAsync();
+				}
+
+				if ( _outputIdentity == ColumnDirection.InputOutput )
+				{
+					await
+						BulkOperationsHelper.LoadFromTmpOutputTableAsync( command, _identityColumn, _outputIdentityDic,
+						OperationType.Delete, _list );
+				}
+
+				if ( handleTransactionInternally )
+				{
+					transaction.Commit();
+				}
+				return affectedRows;
+			}
+
+
+			catch ( SqlException e )
+			{
+				for ( int i = 0; i < e.Errors.Count; i++ )
+				{
+					// Error 8102 is identity error. 
+					if ( e.Errors[i].Number == 8102 )
+					{
+						// Expensive but neccessary to inform user of an important configuration setup. 
+						throw new IdentityException( e.Errors[i].Message );
+					}
+				}
+				if ( handleTransactionInternally )
+				{
+					transaction.Rollback();
+				}
+				throw;
+			}
+
+			catch ( Exception )
+			{
+				if ( handleTransactionInternally )
+				{
+					transaction.Rollback();
+				}
+				throw;
+			}
+			finally
+			{
+				if ( handleTransactionInternally )
+				{
+					transaction.Dispose();
+				}
+				if ( handleConnectionInternally )
+				{
+					conn.Close();
+					conn.Dispose();
+				}
+			}
+		}
+	}
 }

--- a/SqlBulkTools/BulkOperations/BulkOperations.cs
+++ b/SqlBulkTools/BulkOperations/BulkOperations.cs
@@ -72,9 +72,10 @@ namespace SqlBulkTools
         /// successful. 
         /// </summary>
         /// <param name="connection"></param>
+        /// <param name="transaction"></param>
         /// <exception cref="ArgumentNullException"></exception>
         /// <exception cref="SqlBulkToolsException"></exception>
-        public int CommitTransaction(SqlConnection connection)
+        public int CommitTransaction(SqlConnection connection, SqlTransaction transaction = null)
         {
             if (connection == null)
                 throw new ArgumentNullException(nameof(connection));
@@ -82,7 +83,7 @@ namespace SqlBulkTools
             if (_transaction == null)
                 throw new SqlBulkToolsException("No setup found. Use the Setup method to build a new setup then try again.");
 
-            return _transaction.CommitTransaction(connection : connection);
+            return _transaction.CommitTransaction(connection : connection, transaction: transaction);
         }
 
 
@@ -91,10 +92,11 @@ namespace SqlBulkTools
         /// successful. 
         /// </summary>
         /// <param name="connection"></param>
+        /// <param name="transaction"></param>
         /// <returns></returns>
         /// <exception cref="ArgumentNullException"></exception>
         /// <exception cref="SqlBulkToolsException"></exception>
-        public async Task<int> CommitTransactionAsync(SqlConnection connection)
+        public async Task<int> CommitTransactionAsync(SqlConnection connection, SqlTransaction transaction = null)
         {
             if (connection == null)
                 throw new ArgumentNullException(nameof(connection));
@@ -102,7 +104,7 @@ namespace SqlBulkTools
             if (_transaction == null)
                 throw new SqlBulkToolsException("No setup found. Use the Setup method to build a new setup then try again.");
 
-            return await _transaction.CommitTransactionAsync(connection : connection);
+            return await _transaction.CommitTransactionAsync(connection : connection, transaction: transaction);
         }
 
         /// <summary>

--- a/SqlBulkTools/BulkOperations/IBulkOperations.cs
+++ b/SqlBulkTools/BulkOperations/IBulkOperations.cs
@@ -14,13 +14,15 @@ namespace SqlBulkTools
         /// 
         /// </summary>
         /// <param name="connection"></param>
-        int CommitTransaction(SqlConnection connection);
+        /// <param name="transaction"></param>
+        int CommitTransaction(SqlConnection connection, SqlTransaction transaction = null);
         /// <summary>
         /// 
         /// </summary>
         /// <param name="connection"></param>
+        /// <param name="transaction"></param>
         /// <returns></returns>
-        Task<int> CommitTransactionAsync(SqlConnection connection);
+        Task<int> CommitTransactionAsync(SqlConnection connection, SqlTransaction transaction = null);
         /// <summary>
         /// 
         /// </summary>

--- a/SqlBulkTools/BulkOperations/ITransaction.cs
+++ b/SqlBulkTools/BulkOperations/ITransaction.cs
@@ -6,7 +6,7 @@ namespace SqlBulkTools
 {
     internal interface ITransaction
     {
-        int CommitTransaction(string connectionName = null, SqlCredential credentials = null, SqlConnection connection = null);
-        Task<int> CommitTransactionAsync(string connectionName = null, SqlCredential credentials = null, SqlConnection connection = null);
+        int CommitTransaction(string connectionName = null, SqlCredential credentials = null, SqlConnection connection = null, SqlTransaction transaction = null);
+        Task<int> CommitTransactionAsync(string connectionName = null, SqlCredential credentials = null, SqlConnection connection = null, SqlTransaction transaction = null);
     }
 }

--- a/SqlBulkTools/BulkOperations/SimpleQuery/Delete/DeleteQueryReady.cs
+++ b/SqlBulkTools/BulkOperations/SimpleQuery/Delete/DeleteQueryReady.cs
@@ -9,177 +9,211 @@ using System.Threading.Tasks;
 // ReSharper disable once CheckNamespace
 namespace SqlBulkTools
 {
-    /// <summary>
-    /// 
-    /// </summary>
-    /// <typeparam name="T"></typeparam>
-    public class DeleteQueryReady<T> : ITransaction
-    {
-        private readonly string _tableName;
-        private readonly string _schema;
-        private readonly HashSet<string> _columns;
-        private readonly Dictionary<string, string> _customColumnMappings;
-        private readonly int _sqlTimeout;
-        private readonly BulkOperations _ext;
-        private readonly List<Condition> _whereConditions;
-        private readonly List<Condition> _andConditions;
-        private readonly List<Condition> _orConditions;
-        private readonly List<SqlParameter> _parameters;
-        private int _conditionSortOrder;
+	/// <summary>
+	/// 
+	/// </summary>
+	/// <typeparam name="T"></typeparam>
+	public class DeleteQueryReady<T> : ITransaction
+	{
+		private readonly string _tableName;
+		private readonly string _schema;
+		private readonly HashSet<string> _columns;
+		private readonly Dictionary<string, string> _customColumnMappings;
+		private readonly int _sqlTimeout;
+		private readonly BulkOperations _ext;
+		private readonly List<Condition> _whereConditions;
+		private readonly List<Condition> _andConditions;
+		private readonly List<Condition> _orConditions;
+		private readonly List<SqlParameter> _parameters;
+		private int _conditionSortOrder;
 
-        /// <summary>
-        /// 
-        /// </summary>
-        /// <param name="tableName"></param>
-        /// <param name="schema"></param>
-        /// <param name="sqlTimeout"></param>
-        /// <param name="ext"></param>
-        /// <param name="conditionSortOrder"></param>
-        /// <param name="whereConditions"></param>
-        /// <param name="parameters"></param>
-        public DeleteQueryReady(string tableName, string schema, 
-            int sqlTimeout, BulkOperations ext, int conditionSortOrder, List<Condition> whereConditions, List<SqlParameter> parameters)
-        {
-            _tableName = tableName;
-            _schema = schema;
-            _sqlTimeout = sqlTimeout;
-            _ext = ext;
-            _ext.SetBulkExt(this);
-            _whereConditions = whereConditions;
-            _andConditions = new List<Condition>();
-            _orConditions = new List<Condition>();
-            _conditionSortOrder = conditionSortOrder;
-            _parameters = parameters;
-        }
+		/// <summary>
+		/// 
+		/// </summary>
+		/// <param name="tableName"></param>
+		/// <param name="schema"></param>
+		/// <param name="sqlTimeout"></param>
+		/// <param name="ext"></param>
+		/// <param name="conditionSortOrder"></param>
+		/// <param name="whereConditions"></param>
+		/// <param name="parameters"></param>
+		public DeleteQueryReady( string tableName, string schema,
+			int sqlTimeout, BulkOperations ext, int conditionSortOrder, List<Condition> whereConditions, List<SqlParameter> parameters )
+		{
+			_tableName = tableName;
+			_schema = schema;
+			_sqlTimeout = sqlTimeout;
+			_ext = ext;
+			_ext.SetBulkExt( this );
+			_whereConditions = whereConditions;
+			_andConditions = new List<Condition>();
+			_orConditions = new List<Condition>();
+			_conditionSortOrder = conditionSortOrder;
+			_parameters = parameters;
+		}
 
 
-        /// <summary>
-        /// 
-        /// </summary>
-        /// <param name="expression"></param>
-        /// <returns></returns>
-        /// <exception cref="SqlBulkToolsException"></exception>
-        public DeleteQueryReady<T> And(Expression<Func<T, bool>> expression)
-        {
-            BulkOperationsHelper.AddPredicate(expression, PredicateType.And, _andConditions, _parameters, 
-                _conditionSortOrder, appendParam: Constants.UniqueParamIdentifier);
-            _conditionSortOrder++;
-            return this;
-        }
+		/// <summary>
+		/// 
+		/// </summary>
+		/// <param name="expression"></param>
+		/// <returns></returns>
+		/// <exception cref="SqlBulkToolsException"></exception>
+		public DeleteQueryReady<T> And( Expression<Func<T, bool>> expression )
+		{
+			BulkOperationsHelper.AddPredicate( expression, PredicateType.And, _andConditions, _parameters,
+				_conditionSortOrder, appendParam: Constants.UniqueParamIdentifier );
+			_conditionSortOrder++;
+			return this;
+		}
 
-        /// <summary>
-        /// 
-        /// </summary>
-        /// <param name="expression"></param>
-        /// <returns></returns>
-        /// <exception cref="SqlBulkToolsException"></exception>
-        public DeleteQueryReady<T> Or(Expression<Func<T, bool>> expression)
-        {
-            BulkOperationsHelper.AddPredicate(expression, PredicateType.Or, _orConditions, _parameters, 
-                _conditionSortOrder, appendParam: Constants.UniqueParamIdentifier);
-            _conditionSortOrder++;
-            return this;
-        }
+		/// <summary>
+		/// 
+		/// </summary>
+		/// <param name="expression"></param>
+		/// <returns></returns>
+		/// <exception cref="SqlBulkToolsException"></exception>
+		public DeleteQueryReady<T> Or( Expression<Func<T, bool>> expression )
+		{
+			BulkOperationsHelper.AddPredicate( expression, PredicateType.Or, _orConditions, _parameters,
+				_conditionSortOrder, appendParam: Constants.UniqueParamIdentifier );
+			_conditionSortOrder++;
+			return this;
+		}
 
-        int ITransaction.CommitTransaction(string connectionName, SqlCredential credentials, SqlConnection connection)
-        {
-            var concatenatedQuery = _whereConditions.Concat(_andConditions).Concat(_orConditions).OrderBy(x => x.SortOrder);
-            
+		int ITransaction.CommitTransaction( string connectionName, SqlCredential credentials, SqlConnection connection, SqlTransaction transaction )
+		{
+			var concatenatedQuery = _whereConditions.Concat( _andConditions ).Concat( _orConditions ).OrderBy( x => x.SortOrder );
 
-            using (SqlConnection conn = BulkOperationsHelper.GetSqlConnection(connectionName, credentials, connection))
-            {
-                conn.Open();
 
-                using (SqlTransaction transaction = conn.BeginTransaction())
-                {
-                    try
-                    {
-                        SqlCommand command = conn.CreateCommand();
-                        command.Connection = conn;
-                        command.Transaction = transaction;
-                        command.CommandTimeout = _sqlTimeout;
+			bool handleConnectionInternally = false;
+			SqlConnection conn = BulkOperationsHelper.GetSqlConnection( connectionName, credentials, connection );
+			if ( conn.State != ConnectionState.Open )
+			{
+				conn.Open();
+				handleConnectionInternally = true;
+			}
+			bool handleTransactionInternally = false;
+			if ( transaction == null )
+			{
+				transaction = conn.BeginTransaction();
+				handleTransactionInternally = true;
+			}
+			try
+			{
+				SqlCommand command = conn.CreateCommand();
+				command.Connection = conn;
+				command.Transaction = transaction;
+				command.CommandTimeout = _sqlTimeout;
 
-                        string fullQualifiedTableName = BulkOperationsHelper.GetFullQualifyingTableName(conn.Database, _schema,
-                            _tableName);
+				string fullQualifiedTableName = BulkOperationsHelper.GetFullQualifyingTableName( conn.Database, _schema,
+					_tableName );
 
-                        string comm = $"DELETE FROM {fullQualifiedTableName} " +
-                                      $"{BulkOperationsHelper.BuildPredicateQuery(concatenatedQuery)}";
+				string comm = $"DELETE FROM {fullQualifiedTableName} " +
+							  $"{BulkOperationsHelper.BuildPredicateQuery( concatenatedQuery )}";
 
-                        command.CommandText = comm;
+				command.CommandText = comm;
 
-                        if (_parameters.Count > 0)
-                        {
-                            command.Parameters.AddRange(_parameters.ToArray());
-                        }
+				if ( _parameters.Count > 0 )
+				{
+					command.Parameters.AddRange( _parameters.ToArray() );
+				}
 
-                        int affectedRows = command.ExecuteNonQuery();
-                        transaction.Commit();
+				int affectedRows = command.ExecuteNonQuery();
+				if ( handleTransactionInternally )
+				{
+					transaction.Commit();
+				}
 
-                        return affectedRows;
-                    }
+				return affectedRows;
+			}
+			catch ( Exception )
+			{
+				if ( handleTransactionInternally )
+				{
+					transaction.Rollback();
+				}
+				throw;
+			}
+			finally
+			{
+				if ( handleTransactionInternally )
+				{
+					transaction.Dispose();
+				}
+				if ( handleConnectionInternally )
+				{
+					conn.Close();
+					conn.Dispose();
+				}
+			}
+		}
 
-                    catch (Exception)
-                    {
-                        transaction.Rollback();
-                        throw;
-                    }
+		async Task<int> ITransaction.CommitTransactionAsync( string connectionName, SqlCredential credentials, SqlConnection connection, SqlTransaction transaction )
+		{
+			var concatenatedQuery = _whereConditions.Concat( _andConditions ).Concat( _orConditions ).OrderBy( x => x.SortOrder );
 
-                    finally
-                    {
-                        conn.Close();
-                    }
-                }
-            }
-        }
+			bool handleConnectionInternally = false;
+			SqlConnection conn = BulkOperationsHelper.GetSqlConnection( connectionName, credentials, connection );
+			if ( conn.State != ConnectionState.Open )
+			{
+				await conn.OpenAsync();
+				handleConnectionInternally = true;
+			}
+			bool handleTransactionInternally = false;
+			if ( transaction == null )
+			{
+				transaction = conn.BeginTransaction();
+				handleTransactionInternally = true;
+			}
+			try
+			{
+				SqlCommand command = conn.CreateCommand();
+				command.Connection = conn;
+				command.Transaction = transaction;
+				command.CommandTimeout = _sqlTimeout;
 
-        async Task<int> ITransaction.CommitTransactionAsync(string connectionName, SqlCredential credentials, SqlConnection connection)
-        {
-            var concatenatedQuery = _whereConditions.Concat(_andConditions).Concat(_orConditions).OrderBy(x => x.SortOrder);
+				string fullQualifiedTableName = BulkOperationsHelper.GetFullQualifyingTableName( conn.Database, _schema,
+					_tableName );
 
-            using (SqlConnection conn = BulkOperationsHelper.GetSqlConnection(connectionName, credentials, connection))
-            {
-                await conn.OpenAsync();
+				string comm = $"DELETE FROM {fullQualifiedTableName} " +
+							  $"{BulkOperationsHelper.BuildPredicateQuery( concatenatedQuery )}";
 
-                using (SqlTransaction transaction = conn.BeginTransaction())
-                {
-                    try
-                    {
-                        SqlCommand command = conn.CreateCommand();
-                        command.Connection = conn;
-                        command.Transaction = transaction;
-                        command.CommandTimeout = _sqlTimeout;
+				command.CommandText = comm;
 
-                        string fullQualifiedTableName = BulkOperationsHelper.GetFullQualifyingTableName(conn.Database, _schema,
-                            _tableName);
+				if ( _parameters.Count > 0 )
+				{
+					command.Parameters.AddRange( _parameters.ToArray() );
+				}
 
-                        string comm = $"DELETE FROM {fullQualifiedTableName} " +
-                                      $"{BulkOperationsHelper.BuildPredicateQuery(concatenatedQuery)}";
+				int affectedRows = await command.ExecuteNonQueryAsync();
+				if ( handleTransactionInternally )
+				{
+					transaction.Commit();
+				}
 
-                        command.CommandText = comm;
-
-                        if (_parameters.Count > 0)
-                        {
-                            command.Parameters.AddRange(_parameters.ToArray());
-                        }
-
-                        int affectedRows = await command.ExecuteNonQueryAsync();
-                        transaction.Commit();
-
-                        return affectedRows;
-                    }
-
-                    catch (Exception)
-                    {
-                        transaction.Rollback();
-                        throw;
-                    }
-
-                    finally
-                    {
-                        conn.Close();
-                    }
-                }
-            }
-        }
-    }
+				return affectedRows;
+			}
+			catch ( Exception )
+			{
+				if ( handleTransactionInternally )
+				{
+					transaction.Rollback();
+				}
+				throw;
+			}
+			finally
+			{
+				if ( handleTransactionInternally )
+				{
+					transaction.Dispose();
+				}
+				if ( handleConnectionInternally )
+				{
+					conn.Close();
+					conn.Dispose();
+				}
+			}
+		}
+	}
 }

--- a/SqlBulkTools/BulkOperations/SimpleQuery/Update/UpdateQueryReady.cs
+++ b/SqlBulkTools/BulkOperations/SimpleQuery/Update/UpdateQueryReady.cs
@@ -9,210 +9,243 @@ using System.Threading.Tasks;
 // ReSharper disable once CheckNamespace
 namespace SqlBulkTools
 {
-    /// <summary>
-    /// 
-    /// </summary>
-    /// <typeparam name="T"></typeparam>
-    public class UpdateQueryReady<T> : ITransaction
-    {
-        private readonly T _singleEntity;
-        private readonly string _tableName;
-        private readonly string _schema;
-        private readonly HashSet<string> _columns;
-        private readonly Dictionary<string, string> _customColumnMappings;
-        private readonly int _sqlTimeout;
-        private readonly BulkOperations _ext;
-        private readonly List<Condition> _whereConditions;
-        private readonly List<Condition> _andConditions;
-        private readonly List<Condition> _orConditions;
-        private readonly List<SqlParameter> _parameters;
-        private int _conditionSortOrder;
+	/// <summary>
+	/// 
+	/// </summary>
+	/// <typeparam name="T"></typeparam>
+	public class UpdateQueryReady<T> : ITransaction
+	{
+		private readonly T _singleEntity;
+		private readonly string _tableName;
+		private readonly string _schema;
+		private readonly HashSet<string> _columns;
+		private readonly Dictionary<string, string> _customColumnMappings;
+		private readonly int _sqlTimeout;
+		private readonly BulkOperations _ext;
+		private readonly List<Condition> _whereConditions;
+		private readonly List<Condition> _andConditions;
+		private readonly List<Condition> _orConditions;
+		private readonly List<SqlParameter> _parameters;
+		private int _conditionSortOrder;
 
-        /// <summary>
-        /// 
-        /// </summary>
-        /// <param name="singleEntity"></param>
-        /// <param name="tableName"></param>
-        /// <param name="schema"></param>
-        /// <param name="columns"></param>
-        /// <param name="customColumnMappings"></param>
-        /// <param name="sqlTimeout"></param>
-        /// <param name="ext"></param>
-        /// <param name="conditionSortOrder"></param>
-        /// <param name="whereConditions"></param>
-        /// <param name="parameters"></param>
-        public UpdateQueryReady(T singleEntity, string tableName, string schema, HashSet<string> columns, Dictionary<string, string> customColumnMappings, 
-            int sqlTimeout, BulkOperations ext, int conditionSortOrder, List<Condition> whereConditions, List<SqlParameter> parameters)
-        {
-            _singleEntity = singleEntity;
-            _tableName = tableName;
-            _schema = schema;
-            _columns = columns;
-            _customColumnMappings = customColumnMappings;
-            _sqlTimeout = sqlTimeout;
-            _ext = ext;
-            _conditionSortOrder = conditionSortOrder;
-            _ext.SetBulkExt(this);
-            _whereConditions = whereConditions;  
-            _andConditions = new List<Condition>();
-            _orConditions = new List<Condition>();
-            _parameters = parameters;
+		/// <summary>
+		/// 
+		/// </summary>
+		/// <param name="singleEntity"></param>
+		/// <param name="tableName"></param>
+		/// <param name="schema"></param>
+		/// <param name="columns"></param>
+		/// <param name="customColumnMappings"></param>
+		/// <param name="sqlTimeout"></param>
+		/// <param name="ext"></param>
+		/// <param name="conditionSortOrder"></param>
+		/// <param name="whereConditions"></param>
+		/// <param name="parameters"></param>
+		public UpdateQueryReady( T singleEntity, string tableName, string schema, HashSet<string> columns, Dictionary<string, string> customColumnMappings,
+			int sqlTimeout, BulkOperations ext, int conditionSortOrder, List<Condition> whereConditions, List<SqlParameter> parameters )
+		{
+			_singleEntity = singleEntity;
+			_tableName = tableName;
+			_schema = schema;
+			_columns = columns;
+			_customColumnMappings = customColumnMappings;
+			_sqlTimeout = sqlTimeout;
+			_ext = ext;
+			_conditionSortOrder = conditionSortOrder;
+			_ext.SetBulkExt( this );
+			_whereConditions = whereConditions;
+			_andConditions = new List<Condition>();
+			_orConditions = new List<Condition>();
+			_parameters = parameters;
 
-        }
-
-
-        /// <summary>
-        /// 
-        /// </summary>
-        /// <param name="expression"></param>
-        /// <returns></returns>
-        /// <exception cref="SqlBulkToolsException"></exception>
-        public UpdateQueryReady<T> And(Expression<Func<T, bool>> expression)
-        {
-            BulkOperationsHelper.AddPredicate(expression, PredicateType.And, _andConditions, _parameters, _conditionSortOrder, appendParam: Constants.UniqueParamIdentifier);
-            _conditionSortOrder++;
-            return this;
-        }
-
-        /// <summary>
-        /// 
-        /// </summary>
-        /// <param name="expression"></param>
-        /// <returns></returns>
-        /// <exception cref="SqlBulkToolsException"></exception>
-        public UpdateQueryReady<T> Or(Expression<Func<T, bool>> expression)
-        {
-            BulkOperationsHelper.AddPredicate(expression, PredicateType.Or, _orConditions, _parameters, _conditionSortOrder, appendParam: Constants.UniqueParamIdentifier);
-            _conditionSortOrder++;
-            return this;
-        }
-
-        int ITransaction.CommitTransaction(string connectionName, SqlCredential credentials, SqlConnection connection)
-        {
-            int affectedRows = 0;
-            if (_singleEntity == null)
-            {
-                return affectedRows;
-            }
-
-            BulkOperationsHelper.DoColumnMappings(_customColumnMappings, _whereConditions);
-            BulkOperationsHelper.DoColumnMappings(_customColumnMappings, _orConditions);
-            BulkOperationsHelper.DoColumnMappings(_customColumnMappings, _andConditions);
-
-            BulkOperationsHelper.AddSqlParamsForUpdateQuery(_parameters, _columns, _singleEntity);
-
-            var concatenatedQuery = _whereConditions.Concat(_andConditions).Concat(_orConditions).OrderBy(x => x.SortOrder);
-            
-
-            using (SqlConnection conn = BulkOperationsHelper.GetSqlConnection(connectionName, credentials, connection))
-            {
-                conn.Open();
-
-                using (SqlTransaction transaction = conn.BeginTransaction())
-                {
-                    try
-                    {
-                        SqlCommand command = conn.CreateCommand();
-                        command.Connection = conn;
-                        command.Transaction = transaction;
-                        command.CommandTimeout = _sqlTimeout;
-
-                        string fullQualifiedTableName = BulkOperationsHelper.GetFullQualifyingTableName(conn.Database, _schema,
-                            _tableName);
-
-                        string comm = $"UPDATE {fullQualifiedTableName} " +
-                                      $"{BulkOperationsHelper.BuildUpdateSet(_columns, fullQualifiedTableName)}" +
-                                      $"{BulkOperationsHelper.BuildPredicateQuery(concatenatedQuery)}";
-
-                        command.CommandText = comm;
-
-                        if (_parameters.Count > 0)
-                        {
-                            command.Parameters.AddRange(_parameters.ToArray());
-                        }
-
-                        affectedRows = command.ExecuteNonQuery();
-                        transaction.Commit();
-
-                        return affectedRows;
-                    }
-
-                    catch (Exception)
-                    {
-                        transaction.Rollback();
-                        throw;
-                    }
-
-                    finally
-                    {
-                        conn.Close();
-                    }
-                }
-            }
-        }
-
-        async Task<int> ITransaction.CommitTransactionAsync(string connectionName, SqlCredential credentials, SqlConnection connection)
-        {
-            int affectedRows = 0;
-            if (_singleEntity == null)
-            {
-                return affectedRows;
-            }
-
-            BulkOperationsHelper.DoColumnMappings(_customColumnMappings, _whereConditions);
-            BulkOperationsHelper.DoColumnMappings(_customColumnMappings, _orConditions);
-            BulkOperationsHelper.DoColumnMappings(_customColumnMappings, _andConditions);
-
-            BulkOperationsHelper.AddSqlParamsForUpdateQuery(_parameters, _columns, _singleEntity);
-
-            var concatenatedQuery = _whereConditions.Concat(_andConditions).Concat(_orConditions).OrderBy(x => x.SortOrder);
+		}
 
 
-            using (SqlConnection conn = BulkOperationsHelper.GetSqlConnection(connectionName, credentials, connection))
-            {
-                await conn.OpenAsync();
+		/// <summary>
+		/// 
+		/// </summary>
+		/// <param name="expression"></param>
+		/// <returns></returns>
+		/// <exception cref="SqlBulkToolsException"></exception>
+		public UpdateQueryReady<T> And( Expression<Func<T, bool>> expression )
+		{
+			BulkOperationsHelper.AddPredicate( expression, PredicateType.And, _andConditions, _parameters, _conditionSortOrder, appendParam: Constants.UniqueParamIdentifier );
+			_conditionSortOrder++;
+			return this;
+		}
 
-                using (SqlTransaction transaction = conn.BeginTransaction())
-                {
-                    try
-                    {
-                        SqlCommand command = conn.CreateCommand();
-                        command.Connection = conn;
-                        command.Transaction = transaction;
-                        command.CommandTimeout = _sqlTimeout;
+		/// <summary>
+		/// 
+		/// </summary>
+		/// <param name="expression"></param>
+		/// <returns></returns>
+		/// <exception cref="SqlBulkToolsException"></exception>
+		public UpdateQueryReady<T> Or( Expression<Func<T, bool>> expression )
+		{
+			BulkOperationsHelper.AddPredicate( expression, PredicateType.Or, _orConditions, _parameters, _conditionSortOrder, appendParam: Constants.UniqueParamIdentifier );
+			_conditionSortOrder++;
+			return this;
+		}
 
-                        string fullQualifiedTableName = BulkOperationsHelper.GetFullQualifyingTableName(conn.Database, _schema,
-                            _tableName);
+		int ITransaction.CommitTransaction( string connectionName, SqlCredential credentials, SqlConnection connection, SqlTransaction transaction )
+		{
+			int affectedRows = 0;
+			if ( _singleEntity == null )
+			{
+				return affectedRows;
+			}
 
-                        string comm = $"UPDATE {fullQualifiedTableName} " +
-                                      $"{BulkOperationsHelper.BuildUpdateSet(_columns, fullQualifiedTableName)}" +
-                                      $"{BulkOperationsHelper.BuildPredicateQuery(concatenatedQuery)}";
+			BulkOperationsHelper.DoColumnMappings( _customColumnMappings, _whereConditions );
+			BulkOperationsHelper.DoColumnMappings( _customColumnMappings, _orConditions );
+			BulkOperationsHelper.DoColumnMappings( _customColumnMappings, _andConditions );
 
-                        command.CommandText = comm;
+			BulkOperationsHelper.AddSqlParamsForUpdateQuery( _parameters, _columns, _singleEntity );
 
-                        if (_parameters.Count > 0)
-                        {
-                            command.Parameters.AddRange(_parameters.ToArray());
-                        }
+			var concatenatedQuery = _whereConditions.Concat( _andConditions ).Concat( _orConditions ).OrderBy( x => x.SortOrder );
 
-                        affectedRows = await command.ExecuteNonQueryAsync();
-                        transaction.Commit();
 
-                        return affectedRows;
-                    }
+			bool handleConnectionInternally = false;
+			SqlConnection conn = BulkOperationsHelper.GetSqlConnection( connectionName, credentials, connection );
+			if ( conn.State != ConnectionState.Open )
+			{
+				conn.Open();
+				handleConnectionInternally = true;
+			}
+			bool handleTransactionInternally = false;
+			if ( transaction == null )
+			{
+				transaction = conn.BeginTransaction();
+				handleTransactionInternally = true;
+			}
+			try
+			{
+				SqlCommand command = conn.CreateCommand();
+				command.Connection = conn;
+				command.Transaction = transaction;
+				command.CommandTimeout = _sqlTimeout;
 
-                    catch (Exception)
-                    {
-                        transaction.Rollback();
-                        throw;
-                    }
+				string fullQualifiedTableName = BulkOperationsHelper.GetFullQualifyingTableName( conn.Database, _schema,
+					_tableName );
 
-                    finally
-                    {
-                        conn.Close();
-                    }
-                }
-            }
-        }
-    }
+				string comm = $"UPDATE {fullQualifiedTableName} " +
+							  $"{BulkOperationsHelper.BuildUpdateSet( _columns, fullQualifiedTableName )}" +
+							  $"{BulkOperationsHelper.BuildPredicateQuery( concatenatedQuery )}";
+
+				command.CommandText = comm;
+
+				if ( _parameters.Count > 0 )
+				{
+					command.Parameters.AddRange( _parameters.ToArray() );
+				}
+
+				affectedRows = command.ExecuteNonQuery();
+				if ( handleTransactionInternally )
+				{
+					transaction.Commit();
+				}
+
+				return affectedRows;
+			}
+			catch ( Exception )
+			{
+				if ( handleTransactionInternally )
+				{
+					transaction.Rollback();
+				}
+				throw;
+			}
+			finally
+			{
+				if ( handleTransactionInternally )
+				{
+					transaction.Dispose();
+				}
+				if ( handleConnectionInternally )
+				{
+					conn.Close();
+					conn.Dispose();
+				}
+			}
+		}
+		async Task<int> ITransaction.CommitTransactionAsync( string connectionName, SqlCredential credentials, SqlConnection connection, SqlTransaction transaction )
+		{
+			int affectedRows = 0;
+			if ( _singleEntity == null )
+			{
+				return affectedRows;
+			}
+
+			BulkOperationsHelper.DoColumnMappings( _customColumnMappings, _whereConditions );
+			BulkOperationsHelper.DoColumnMappings( _customColumnMappings, _orConditions );
+			BulkOperationsHelper.DoColumnMappings( _customColumnMappings, _andConditions );
+
+			BulkOperationsHelper.AddSqlParamsForUpdateQuery( _parameters, _columns, _singleEntity );
+
+			var concatenatedQuery = _whereConditions.Concat( _andConditions ).Concat( _orConditions ).OrderBy( x => x.SortOrder );
+
+
+			bool handleConnectionInternally = false;
+			SqlConnection conn = BulkOperationsHelper.GetSqlConnection( connectionName, credentials, connection );
+			if ( conn.State != ConnectionState.Open )
+			{
+				await conn.OpenAsync();
+				handleConnectionInternally = true;
+			}
+			bool handleTransactionInternally = false;
+			if ( transaction == null )
+			{
+				transaction = conn.BeginTransaction();
+				handleTransactionInternally = true;
+			}
+			try
+			{
+				SqlCommand command = conn.CreateCommand();
+				command.Connection = conn;
+				command.Transaction = transaction;
+				command.CommandTimeout = _sqlTimeout;
+
+				string fullQualifiedTableName = BulkOperationsHelper.GetFullQualifyingTableName( conn.Database, _schema,
+					_tableName );
+
+				string comm = $"UPDATE {fullQualifiedTableName} " +
+							  $"{BulkOperationsHelper.BuildUpdateSet( _columns, fullQualifiedTableName )}" +
+							  $"{BulkOperationsHelper.BuildPredicateQuery( concatenatedQuery )}";
+
+				command.CommandText = comm;
+
+				if ( _parameters.Count > 0 )
+				{
+					command.Parameters.AddRange( _parameters.ToArray() );
+				}
+
+				affectedRows = await command.ExecuteNonQueryAsync();
+				if ( handleTransactionInternally )
+				{
+					transaction.Commit();
+				}
+
+				return affectedRows;
+			}
+			catch ( Exception )
+			{
+				if ( handleTransactionInternally )
+				{
+					transaction.Rollback();
+				}
+				throw;
+			}
+			finally
+			{
+				if ( handleTransactionInternally )
+				{
+					transaction.Dispose();
+				}
+				if ( handleConnectionInternally )
+				{
+					conn.Close();
+					conn.Dispose();
+				}
+			}
+		}
+	}
 }

--- a/SqlBulkTools/Helper/BulkOperationsHelper.cs
+++ b/SqlBulkTools/Helper/BulkOperationsHelper.cs
@@ -11,1232 +11,1249 @@ using System.Runtime.CompilerServices;
 using System.Text;
 using System.Threading.Tasks;
 
-[assembly: InternalsVisibleTo("SqlBulkTools.UnitTests")]
-[assembly: InternalsVisibleTo("SqlBulkTools.IntegrationTests")]
+[assembly: InternalsVisibleTo( "SqlBulkTools.UnitTests" )]
+[assembly: InternalsVisibleTo( "SqlBulkTools.IntegrationTests" )]
 namespace SqlBulkTools
 {
-    internal static class BulkOperationsHelper
-    {
-
-        internal struct PrecisionType
-        {
-            public string NumericPrecision { get; set; }
-            public string NumericScale { get; set; }
-        }
-
-        internal static string BuildCreateTempTable(HashSet<string> columns, DataTable schema, ColumnDirection outputIdentity)
-        {
-            Dictionary<string, string> actualColumns = new Dictionary<string, string>();
-            Dictionary<string, string> actualColumnsMaxCharLength = new Dictionary<string, string>();
-            Dictionary<string, PrecisionType> actualColumnsNumericPrecision = new Dictionary<string, PrecisionType>();
-            Dictionary<string, string> actualColumnsDateTimePrecision = new Dictionary<string, string>();
-
-
-            foreach (DataRow row in schema.Rows)
-            {
-                string columnType = row["DATA_TYPE"].ToString();
-                string columnName = row["COLUMN_NAME"].ToString();
-
-                actualColumns.Add(row["COLUMN_NAME"].ToString(), row["DATA_TYPE"].ToString());
-
-                if (columnType == "varchar" || columnType == "nvarchar" ||
-                    columnType == "char" || columnType == "binary" ||
-                    columnType == "varbinary" || columnType == "nchar")
-
-                {
-                    actualColumnsMaxCharLength.Add(row["COLUMN_NAME"].ToString(),
-                        row["CHARACTER_MAXIMUM_LENGTH"].ToString());
-                }
-
-                if (columnType == "datetime2" || columnType == "time")
-                {
-                    actualColumnsDateTimePrecision.Add(row["COLUMN_NAME"].ToString(), row["DATETIME_PRECISION"].ToString());
-                }
-
-                if (columnType == "numeric" || columnType == "decimal")
-                {
-                    PrecisionType p = new PrecisionType
-                    {
-                        NumericPrecision = row["NUMERIC_PRECISION"].ToString(),
-                        NumericScale = row["NUMERIC_SCALE"].ToString()
-                    };
-                    actualColumnsNumericPrecision.Add(columnName, p);
-                }
-
-            }
-
-            StringBuilder command = new StringBuilder();
-
-            command.Append("CREATE TABLE " + Constants.TempTableName + "(");
-
-            List<string> paramList = new List<string>();
-
-            foreach (var column in columns.ToList())
-            {
-                if (column == Constants.InternalId)
-                    continue;
-                string columnType;
-                if (actualColumns.TryGetValue(column, out columnType))
-                {
-                    columnType = GetVariableCharType(column, columnType, actualColumnsMaxCharLength);
-                    columnType = GetDecimalPrecisionAndScaleType(column, columnType, actualColumnsNumericPrecision);
-                    columnType = GetDateTimePrecisionType(column, columnType, actualColumnsDateTimePrecision);
-                }
-
-                paramList.Add("[" + column + "]" + " " + columnType);
-            }
-
-            string paramListConcatenated = string.Join(", ", paramList);
-
-            command.Append(paramListConcatenated);
-
-            if (outputIdentity == ColumnDirection.InputOutput)
-            {
-                command.Append(", [" + Constants.InternalId + "] int");
-            }
-            command.Append(");");
-
-            return command.ToString();
-        }
-
-        private static string GetVariableCharType(string column, string columnType, Dictionary<string, string> actualColumnsMaxCharLength)
-        {
-            if (columnType == "varchar" || columnType == "nvarchar" ||
-                    columnType == "char" || columnType == "binary" ||
-                    columnType == "varbinary" || columnType == "nchar")
-            {
-                string maxCharLength;
-                if (actualColumnsMaxCharLength.TryGetValue(column, out maxCharLength))
-                {
-                    if (maxCharLength == "-1")
-                        maxCharLength = "max";
-
-                    columnType = columnType + "(" + maxCharLength + ")";
-                }
-            }
-
-            return columnType;
-        }
-
-        private static string GetDecimalPrecisionAndScaleType(string column, string columnType, Dictionary<string, PrecisionType> actualColumnsPrecision)
-        {
-            if (columnType == "decimal" || columnType == "numeric")
-            {
-                PrecisionType p;
-
-                if (actualColumnsPrecision.TryGetValue(column, out p))
-                {
-                    columnType = columnType + "(" + p.NumericPrecision + ", " + p.NumericScale + ")";
-                }
-            }
-
-            return columnType;
-        }
-
-        private static string GetDateTimePrecisionType(string column, string columnType, Dictionary<string, string> actualColumnsDateTimePrecision)
-        {
-            if (columnType == "datetime2" || columnType == "time")
-            {
-                string dateTimePrecision;
-                if (actualColumnsDateTimePrecision.TryGetValue(column, out dateTimePrecision))
-                {
-
-                    columnType = columnType + "(" + dateTimePrecision + ")";
-                }
-            }
-
-            return columnType;
-        }
-
-        internal static string BuildJoinConditionsForUpdateOrInsert(string[] updateOn, string sourceAlias, string targetAlias)
-        {
-            StringBuilder command = new StringBuilder();
-
-            command.Append("ON " + "[" + targetAlias + "]" + "." + "[" + updateOn[0] + "]" + " = " + "[" + sourceAlias + "]" + "."
-                + "[" + updateOn[0] + "]" + " ");
-
-            if (updateOn.Length > 1)
-            {
-                // Start from index 1 to just append "AND" conditions
-                for (int i = 1; i < updateOn.Length; i++)
-                {
-                    command.Append("AND " + "[" + targetAlias + "]" + "." + "[" + updateOn[i] + "]" + " = " + "[" +
-                        sourceAlias + "]" + "." + "[" + updateOn[i] + "]" + " ");
-                }
-            }
-
-            return command.ToString();
-        }
-
-        internal static string BuildPredicateQuery(string[] updateOn, IEnumerable<Condition> conditions, string targetAlias)
-        {
-            if (conditions == null)
-                return null;
-
-            if (updateOn == null || updateOn.Length == 0)
-                throw new SqlBulkToolsException("MatchTargetOn is required for AndQuery.");
-
-            StringBuilder command = new StringBuilder();
-
-            foreach (var condition in conditions)
-            {
-                string targetColumn = condition.CustomColumnMapping ?? condition.LeftName;
-
-                command.Append("AND [" + targetAlias + "].[" + targetColumn + "] " +
-                               GetOperator(condition) + " " + (condition.Value != "NULL" ? ("@" + 
-                               condition.LeftName + Constants.UniqueParamIdentifier + condition.SortOrder) : "NULL") + " ");
-            }
-
-            return command.ToString();
-
-        }
-
-        // Used for UpdateQuery and DeleteQuery where, and, or conditions. 
-        internal static string BuildPredicateQuery(IEnumerable<Condition> conditions)
-        {
-            if (conditions == null)
-                return null;
-
-            conditions = conditions.OrderBy(x => x.SortOrder);
-
-            StringBuilder command = new StringBuilder();
-
-            foreach (var condition in conditions)
-            {
-                string targetColumn = condition.CustomColumnMapping ?? condition.LeftName;
-
-                switch (condition.PredicateType)
-                {
-                    case PredicateType.Where:
-                    {
-                        command.Append(" WHERE ");
-                        break;
-                    }
-
-                    case PredicateType.And:
-                    {
-                            command.Append(" AND ");
-                            break;
-                    }
-
-                    case PredicateType.Or:
-                        {
-                            command.Append(" OR ");
-                            break;
-                        }
-
-                    default:
-                    {
-                        throw new KeyNotFoundException("Predicate not found");
-                    }
-                }
-
-                command.Append("[" + targetColumn + "] " +
-                               GetOperator(condition) + " " + (condition.Value != "NULL" ? ("@" + condition.LeftName + Constants.UniqueParamIdentifier + condition.SortOrder) : "NULL"));
-            }
-
-            return command.ToString();
-
-        }
-
-        internal static string GetOperator(Condition condition)
-        {
-            switch (condition.Expression)
-            {
-                case ExpressionType.NotEqual:
-                    {
-                        if (condition.ValueType == null)
-                        {
-                            condition.Value = condition.Value?.ToUpper();
-                            return "IS NOT";
-                        }
-
-                        return "!=";
-                    }
-                case ExpressionType.Equal:
-                    {
-                        if (condition.ValueType == null)
-                        {
-                            condition.Value = condition.Value?.ToUpper();
-                            return "IS";
-                        }
-
-                        return "=";
-                    }
-                case ExpressionType.LessThan:
-                    {
-                        return "<";
-                    }
-                case ExpressionType.LessThanOrEqual:
-                    {
-                        return "<=";
-                    }
-                case ExpressionType.GreaterThan:
-                    {
-                        return ">";
-                    }
-                case ExpressionType.GreaterThanOrEqual:
-                    {
-                        return ">=";
-                    }
-            }
-
-            throw new SqlBulkToolsException("ExpressionType not found when trying to map logical operator.");
-
-        }
-
-        internal static string BuildUpdateSet(HashSet<string> columns, string sourceAlias, string targetAlias, string identityColumn)
-        {
-            StringBuilder command = new StringBuilder();
-            List<string> paramsSeparated = new List<string>();
-
-            command.Append("SET ");
-
-            foreach (var column in columns.ToList())
-            {
-                if (identityColumn != null && column != identityColumn || identityColumn == null)
-                {
-                    if (column != Constants.InternalId)
-                        paramsSeparated.Add("[" + targetAlias + "]" + "." + "[" + column + "]" + " = " + "[" + sourceAlias + "]" + "."
-                            + "[" + column + "]");
-                }
-            }
-
-            command.Append(string.Join(", ", paramsSeparated) + " ");
-
-            return command.ToString();
-        }
-
-        /// <summary>
-        /// Specificially for UpdateQuery and DeleteQuery
-        /// </summary>
-        /// <param name="columns"></param>
-        /// <param name="fullQualifiedTableName"></param>
-        /// <returns></returns>
-        internal static string BuildUpdateSet(HashSet<string> columns, string fullQualifiedTableName)
-        {
-            StringBuilder command = new StringBuilder();
-            List<string> paramsSeparated = new List<string>();
-
-            command.Append("SET ");
-
-            foreach (var column in columns.ToList())
-            {
-                paramsSeparated.Add(fullQualifiedTableName + "." + "[" + column + "]" + " = @" + column);
-            }
-
-            command.Append(string.Join(", ", paramsSeparated));
-
-            return command.ToString();
-        }
-
-        internal static string BuildInsertSet(HashSet<string> columns, string sourceAlias, string identityColumn)
-        {
-            StringBuilder command = new StringBuilder();
-            List<string> insertColumns = new List<string>();
-            List<string> values = new List<string>();
-
-            command.Append("INSERT (");
-
-            foreach (var column in columns.ToList())
-            {
-
-                if (column != Constants.InternalId && column != identityColumn)
-                {
-                    insertColumns.Add("[" + column + "]");
-                    values.Add("[" + sourceAlias + "]" + "." + "[" + column + "]");
-                }
-
-            }
-
-            command.Append(string.Join(", ", insertColumns));
-            command.Append(") values (");
-            command.Append(string.Join(", ", values));
-            command.Append(")");
-
-            return command.ToString();
-        }
-
-        internal static string BuildInsertIntoSet(HashSet<string> columns, string identityColumn, string tableName)
-        {
-            StringBuilder command = new StringBuilder();
-            List<string> insertColumns = new List<string>();
-
-            command.Append("INSERT INTO ");
-            command.Append(tableName);
-            command.Append(" (");
-
-            foreach (var column in columns)
-            {
-                if (column != Constants.InternalId && column != identityColumn)
-                    insertColumns.Add("[" + column + "]");
-            }
-
-            command.Append(string.Join(", ", insertColumns));
-            command.Append(") ");
-
-            return command.ToString();
-        }
-
-        internal static string BuildSelectSet(HashSet<string> columns, string sourceAlias, string identityColumn)
-        {
-            StringBuilder command = new StringBuilder();
-            List<string> selectColumns = new List<string>();
-            List<string> values = new List<string>();
-
-            command.Append("SELECT ");
-
-            foreach (var column in columns.ToList())
-            {
-                if (identityColumn != null && column != identityColumn || identityColumn == null)
-                {
-                    if (column != Constants.InternalId)
-                    {
-                        selectColumns.Add("[" + sourceAlias + "].[" + column + "]");
-                        values.Add("[" + column + "]");
-                    }
-                }
-            }
-
-            command.Append(string.Join(", ", selectColumns));
-
-            return command.ToString();
-        }
-
-        internal static string GetPropertyName(Expression method)
-        {
-            LambdaExpression lambda = method as LambdaExpression;
-            if (lambda == null)
-                throw new ArgumentNullException("method");
-
-            MemberExpression memberExpr = null;
-
-            if (lambda.Body.NodeType == ExpressionType.Convert)
-            {
-                memberExpr =
-                    ((UnaryExpression)lambda.Body).Operand as MemberExpression;
-            }
-            else if (lambda.Body.NodeType == ExpressionType.MemberAccess)
-            {
-                memberExpr = lambda.Body as MemberExpression;
-            }
-
-            if (memberExpr == null)
-                throw new ArgumentException("method");
-
-            return memberExpr.Member.Name;
-        }
-
-        internal static DataTable CreateDataTable<T>(HashSet<string> columns, Dictionary<string, string> columnMappings,
-            List<string> matchOnColumns = null, ColumnDirection? outputIdentity = null)
-        {
-            if (columns == null)
-                return null;
-
-            DataTable dataTable = new DataTable(typeof(T).Name);
-
-            if (matchOnColumns != null)
-            {
-                columns = CheckForAdditionalColumns(columns, matchOnColumns);
-            }
-
-            if (outputIdentity.HasValue && outputIdentity.Value == ColumnDirection.InputOutput)
-            {
-                columns.Add(Constants.InternalId);
-            }
-
-            //Get all the properties
-            PropertyInfo[] props = typeof(T).GetProperties(BindingFlags.Public | BindingFlags.Instance);
-
-            foreach (var column in columns.ToList())
-            {
-                if (columnMappings != null && columnMappings.ContainsKey(column))
-                {
-                    dataTable.Columns.Add(columnMappings[column]);
-                }
-
-                else
-                    dataTable.Columns.Add(column);
-            }
-
-            AssignTypes(props, columns, dataTable);
-
-            return dataTable;
-        }
-
-        public static DataTable ConvertListToDataTable<T>(DataTable dataTable, IEnumerable<T> list, HashSet<string> columns,
-            Dictionary<int, T> outputIdentityDic = null)
-        {
-
-            PropertyInfo[] props = typeof(T).GetProperties(BindingFlags.Public | BindingFlags.Instance);
-
-            int counter = 0;
-
-            foreach (T item in list)
-            {
-
-                var values = new List<object>();
-
-                foreach (var column in columns.ToList())
-                {
-                    if (column == Constants.InternalId)
-                    {
-                        values.Add(counter);
-                        outputIdentityDic?.Add(counter, item);
-                    }
-                    else
-                        for (int i = 0; i < props.Length; i++)
-                        {
-                            if (props[i].Name == column && item != null
-                                && CheckForValidDataType(props[i].PropertyType, throwIfInvalid: true))
-                                values.Add(props[i].GetValue(item, null));
-
-
-                        }
-
-                }
-                counter++;
-                dataTable.Rows.Add(values.ToArray());
-
-            }
-            return dataTable;
-
-        }
-
-        // Loops through object properties, checks if column has been added, adds as sql parameter. Used for the UpdateQuery method. 
-        public static void AddSqlParamsForUpdateQuery<T>(List<SqlParameter> sqlParameters, HashSet<string> columns, T item)
-        {
-            PropertyInfo[] props = typeof(T).GetProperties(BindingFlags.Public | BindingFlags.Instance);
-
-            foreach (var column in columns.ToList())
-            {
-                for (int i = 0; i < props.Length; i++)
-                {
-                    if (props[i].Name == column && item != null && CheckForValidDataType(props[i].PropertyType, throwIfInvalid: true))
-                    {
-                        DbType sqlType = SqlTypeMap.GetSqlTypeFromNetType(props[i].PropertyType);
-                        SqlParameter param = new SqlParameter($"@{column}", sqlType);
-                        param.Value = props[i].GetValue(item, null);
-
-                        sqlParameters.Add(param);
-                    }
-                }
-            }
-        }
-
-        /// <summary>
-        /// 
-        /// </summary>
-        /// <param name="type"></param>
-        /// <param name="throwIfInvalid">
-        /// Set this to true if user is manually adding columns. If AddAllColumns is used, then this can be omitted. 
-        /// </param>
-        /// <returns></returns>
-        private static bool CheckForValidDataType(Type type, bool throwIfInvalid = false)
-        {
-            if (type.IsValueType ||
-                type == typeof(string) ||
-                type == typeof(byte[]) ||
-                type == typeof(char[]) ||
-                type == typeof(SqlXml)
-                )
-                return true;
-
-            if (throwIfInvalid)
-                throw new SqlBulkToolsException("Only value, string, char[], byte[] " +
-                                                    "and SqlXml types can be used with SqlBulkTools. " +
-                                                    "Refer to https://msdn.microsoft.com/en-us/library/cc716729(v=vs.110).aspx for more details.");
-
-            return false;
-        }
-
-        private static void AssignTypes(PropertyInfo[] props, HashSet<string> columns, DataTable dataTable)
-        {
-            int count = 0;
-
-            foreach (var column in columns.ToList())
-            {
-                if (column == Constants.InternalId)
-                {
-                    dataTable.Columns[count].DataType = typeof(int);
-                }
-                else
-                    for (int i = 0; i < props.Length; i++)
-                    {
-                        if (props[i].Name == column)
-                        {
-                            dataTable.Columns[count].DataType = Nullable.GetUnderlyingType(props[i].PropertyType) ??
-                                                                props[i].PropertyType;
-                        }
-                    }
-                count++;
-            }
-        }
-
-        internal static SqlConnection GetSqlConnection(string connectionName, SqlCredential credentials, SqlConnection connection)
-        {
-            SqlConnection conn = null;
-
-            if (connection != null)
-            {
-                conn = connection;
-                return conn;
-            }
-
-            if (connectionName != null)
-            {
-                conn = new SqlConnection(ConfigurationManager
-                    .ConnectionStrings[connectionName].ConnectionString, credentials);
-                return conn;
-            }
-
-            throw new SqlBulkToolsException("Could not create SQL connection. Please check your arguments into CommitTransaction");
-        }
-
-        internal static string GetFullQualifyingTableName(string databaseName, string schemaName, string tableName)
-        {
-            StringBuilder sb = new StringBuilder();
-            sb.Append("[");
-            sb.Append(databaseName);
-            sb.Append("].[");
-            sb.Append(schemaName);
-            sb.Append("].[");
-            sb.Append(tableName);
-            sb.Append("]");
-
-            return sb.ToString();
-        }
-
-
-        /// <summary>
-        /// If there are MatchOnColumns that don't exist in columns, add to columns.
-        /// </summary>
-        /// <param name="columns"></param>
-        /// <param name="matchOnColumns"></param>
-        /// <returns></returns>
-        internal static HashSet<string> CheckForAdditionalColumns(HashSet<string> columns, List<string> matchOnColumns)
-        {
-            foreach (var col in matchOnColumns)
-            {
-                if (!columns.Contains(col))
-                {
-                    columns.Add(col);
-                }
-            }
-
-            return columns;
-        }
-
-        internal static void DoColumnMappings(Dictionary<string, string> columnMappings, HashSet<string> columns,
-        List<string> updateOnList)
-        {
-            if (columnMappings.Count > 0)
-            {
-                foreach (var column in columnMappings)
-                {
-                    if (columns.Contains(column.Key))
-                    {
-                        columns.Remove(column.Key);
-                        columns.Add(column.Value);
-                    }
-
-                    for (int i = 0; i < updateOnList.ToArray().Length; i++)
-                    {
-                        if (updateOnList[i] == column.Key)
-                        {
-                            updateOnList[i] = column.Value;
-                        }
-                    }
-                }
-            }
-        }
-
-        internal static void DoColumnMappings(Dictionary<string, string> columnMappings, HashSet<string> columns)
-        {
-            if (columnMappings.Count > 0)
-            {
-                foreach (var column in columnMappings)
-                {
-                    if (columns.Contains(column.Key))
-                    {
-                        columns.Remove(column.Key);
-                        columns.Add(column.Value);
-                    }
-                }
-            }
-        }
-
-        internal static void DoColumnMappings(Dictionary<string, string> columnMappings, List<Condition> predicateConditions)
-        {
-            foreach (var condition in predicateConditions)
-            {
-                string columnName;
-
-                if (columnMappings.TryGetValue(condition.LeftName, out columnName))
-                {
-                    condition.CustomColumnMapping = columnName;
-                }
-            }
-        }
-
-        /// <summary>
-        /// Advanced Settings for SQLBulkCopy class. 
-        /// </summary>
-        /// <param name="bulkcopy"></param>
-        /// <param name="bulkCopyEnableStreaming"></param>
-        /// <param name="bulkCopyBatchSize"></param>
-        /// <param name="bulkCopyNotifyAfter"></param>
-        /// <param name="bulkCopyTimeout"></param>
-        /// <param name="bulkCopyDelegates"></param>
-        internal static void SetSqlBulkCopySettings(SqlBulkCopy bulkcopy, bool bulkCopyEnableStreaming, int? bulkCopyBatchSize,
-            int? bulkCopyNotifyAfter, int bulkCopyTimeout, IEnumerable<SqlRowsCopiedEventHandler> bulkCopyDelegates)
-        {
-            bulkcopy.EnableStreaming = bulkCopyEnableStreaming;
-
-            if (bulkCopyBatchSize.HasValue)
-            {
-                bulkcopy.BatchSize = bulkCopyBatchSize.Value;
-            }
-
-            if (bulkCopyNotifyAfter.HasValue)
-            {
-                bulkcopy.NotifyAfter = bulkCopyNotifyAfter.Value;
-                bulkCopyDelegates?.ToList().ForEach(x => bulkcopy.SqlRowsCopied += x);
-            }
-
-            bulkcopy.BulkCopyTimeout = bulkCopyTimeout;
-        }
-
-
-        /// <summary>
-        /// This is used only for the BulkInsert method at this time.  
-        /// </summary>
-        /// <param name="bulkCopy"></param>
-        /// <param name="columns"></param>
-        /// <param name="customColumnMappings"></param>
-        internal static void MapColumns(SqlBulkCopy bulkCopy, HashSet<string> columns, Dictionary<string, string> customColumnMappings)
-        {
-
-            foreach (var column in columns.ToList())
-            {
-                string mapping;
-
-                if (customColumnMappings.TryGetValue(column, out mapping))
-                {
-                    bulkCopy.ColumnMappings.Add(mapping, mapping);
-                }
-
-                else
-                    bulkCopy.ColumnMappings.Add(column, column);
-            }
-
-        }
-
-        internal static HashSet<string> GetAllValueTypeAndStringColumns(Type type)
-        {
-            HashSet<string> columns = new HashSet<string>();
-
-            //Get all the properties
-            PropertyInfo[] props = type.GetProperties(BindingFlags.Public | BindingFlags.Instance);
-
-            for (int i = 0; i < props.Length; i++)
-            {
-                if (CheckForValidDataType(props[i].PropertyType))
-                {
-                    columns.Add(props[i].Name);
-                }
-            }
-
-            return columns;
-
-        }
-
-        internal static string GetOutputIdentityCmd(string identityColumn, ColumnDirection outputIdentity, string tmpTableName, OperationType operation)
-        {
-
-            StringBuilder sb = new StringBuilder();
-            if (identityColumn == null || outputIdentity != ColumnDirection.InputOutput)
-            {
-                return null;
-            }
-            if (operation == OperationType.Insert)
-                sb.Append("OUTPUT INSERTED." + identityColumn + " INTO " + tmpTableName + "(" + identityColumn + "); ");
-
-            else if (operation == OperationType.InsertOrUpdate || operation == OperationType.Update)
-                sb.Append("OUTPUT Source." + Constants.InternalId + ", INSERTED." + identityColumn + " INTO " + tmpTableName
-                    + "(" + Constants.InternalId + ", " + identityColumn + "); ");
-
-            else if (operation == OperationType.Delete)
-                sb.Append("OUTPUT Source." + Constants.InternalId + ", DELETED." + identityColumn + " INTO " + tmpTableName
-                    + "(" + Constants.InternalId + ", " + identityColumn + "); ");
-
-            return sb.ToString();
-        }
-
-        internal static string GetOutputCreateTableCmd(ColumnDirection outputIdentity, string tmpTablename, OperationType operation, string identityColumn)
-        {
-
-            if (operation == OperationType.Insert)
-                return (outputIdentity == ColumnDirection.InputOutput ? "CREATE TABLE " + tmpTablename + "(" + "[" + identityColumn + "] int); " : "");
-
-            else if (operation == OperationType.InsertOrUpdate || operation == OperationType.Update || operation == OperationType.Delete)
-                return (outputIdentity == ColumnDirection.InputOutput ? "CREATE TABLE " + tmpTablename + "("
-                    + "[" + Constants.InternalId + "]" + " int, [" + identityColumn + "] int); " : "");
-
-            return string.Empty;
-        }
-
-        internal static string GetDropTmpTableCmd()
-        {
-            return "DROP TABLE " + Constants.TempOutputTableName + ";";
-        }
-
-        internal static string GetIndexManagementCmd(string action, string tableName,
-            string schema, IDbConnection conn, HashSet<string> disableIndexList, bool disableAllIndexes = false)
-        {
-            StringBuilder sb = new StringBuilder();
-
-            if (disableIndexList != null && disableIndexList.Any())
-            {
-                foreach (var index in disableIndexList)
-                {
-                    sb.Append(" AND sys.indexes.name = \'");
-                    sb.Append(index);
-                    sb.Append("\'");
-                }
-            }
-
-            string cmd = "DECLARE @sql AS VARCHAR(MAX)=''; " +
-                                "SELECT @sql = @sql + " +
-                                "'ALTER INDEX ' + sys.indexes.name + ' ON ' + sys.objects.name + ' " + action + ";' " +
-                                "FROM sys.indexes JOIN sys.objects ON sys.indexes.object_id = sys.objects.object_id " +
-                                "WHERE sys.indexes.type_desc = 'NONCLUSTERED' " +
-                                "AND sys.objects.type_desc = 'USER_TABLE' " +
-                                "AND sys.objects.name = '" + GetFullQualifyingTableName(conn.Database, schema, tableName)
-                                + "'" + (sb.Length > 0 ? sb.ToString() : "") + "; EXEC(@sql);";
-
-            return cmd;
-        }
-
-        /// <summary>
-        /// Gets schema information for a table. Used to get SQL type of property. 
-        /// </summary>
-        /// <param name="conn"></param>
-        /// <param name="schema"></param>
-        /// <param name="tableName"></param>
-        /// <returns></returns>
-        internal static DataTable GetDatabaseSchema(SqlConnection conn, string schema, string tableName)
-        {
-            string[] restrictions = new string[4];
-            restrictions[0] = conn.Database;
-            restrictions[1] = schema;
-            restrictions[2] = tableName;
-            var dtCols = conn.GetSchema("Columns", restrictions);
-
-            if (dtCols.Rows.Count == 0 && schema != null)
-                throw new SqlBulkToolsException("Table name '" + tableName
-                + "\' with schema name \'" + schema + "\' not found. Check your setup and try again.");
-
-            if (dtCols.Rows.Count == 0)
-                throw new SqlBulkToolsException("Table name \'" + tableName
-                + "\' not found. Check your setup and try again.");
-            return dtCols;
-        }
-
-        internal static void InsertToTmpTable(SqlConnection conn, SqlTransaction transaction, DataTable dt, bool bulkCopyEnableStreaming,
-            int? bulkCopyBatchSize, int? bulkCopyNotifyAfter, int bulkCopyTimeout, SqlBulkCopyOptions sqlBulkCopyOptions, IEnumerable<SqlRowsCopiedEventHandler> bulkCopyDelegates)
-        {
-            using (SqlBulkCopy bulkcopy = new SqlBulkCopy(conn, sqlBulkCopyOptions, transaction))
-            {
-                bulkcopy.DestinationTableName = Constants.TempTableName;
-
-                SetSqlBulkCopySettings(bulkcopy, bulkCopyEnableStreaming,
-                    bulkCopyBatchSize,
-                    bulkCopyNotifyAfter, bulkCopyTimeout, bulkCopyDelegates);
-
-                bulkcopy.WriteToServer(dt);
-            }
-        }
-
-        internal static async Task InsertToTmpTableAsync(SqlConnection conn, SqlTransaction transaction, DataTable dt, bool bulkCopyEnableStreaming,
-            int? bulkCopyBatchSize, int? bulkCopyNotifyAfter, int bulkCopyTimeout, SqlBulkCopyOptions sqlBulkCopyOptions, IEnumerable<SqlRowsCopiedEventHandler> bulkCopyDelegates)
-        {
-            using (SqlBulkCopy bulkcopy = new SqlBulkCopy(conn, sqlBulkCopyOptions, transaction))
-            {
-                bulkcopy.DestinationTableName = Constants.TempTableName;
-
-                SetSqlBulkCopySettings(bulkcopy, bulkCopyEnableStreaming,
-                    bulkCopyBatchSize,
-                    bulkCopyNotifyAfter, bulkCopyTimeout, bulkCopyDelegates);
-
-                await bulkcopy.WriteToServerAsync(dt);
-            }
-        }
-
-        internal static void LoadFromTmpOutputTable<T>(SqlCommand command, string identityColumn, Dictionary<int, T> outputIdentityDic,
-            OperationType operationType, IEnumerable<T> list)
-        {
-            if (operationType == OperationType.InsertOrUpdate
-                || operationType == OperationType.Update
-                || operationType == OperationType.Delete)
-            {
-                command.CommandText = "SELECT " + Constants.InternalId + ", " + identityColumn + " FROM "
-                    + Constants.TempOutputTableName + ";";
-
-                using (SqlDataReader reader = command.ExecuteReader())
-                {
-                    while (reader.Read())
-                    {
-                        T item;
-
-                        if (outputIdentityDic.TryGetValue((int)reader[0], out item))
-                        {
-                            PropertyInfo p = item.GetType().GetProperty(identityColumn);
-
-                            if (p.CanWrite)
-                                p.SetValue(item, reader[1], null);
-
-                            else
-                                throw new SqlBulkToolsException(GetPrivateSetterExceptionMessage(identityColumn));
-                        }
-
-                    }
-                }
-
-                command.CommandText = GetDropTmpTableCmd();
-                command.ExecuteNonQuery();
-            }
-
-            if (operationType == OperationType.Insert)
-            {
-                command.CommandText = "SELECT " + identityColumn + " FROM " + Constants.TempOutputTableName + ";";
-
-                using (SqlDataReader reader = command.ExecuteReader())
-                {
-                    var items = list.ToList();
-                    int counter = 0;
-
-                    while (reader.Read())
-                    {
-                        PropertyInfo p = items[counter].GetType().GetProperty(identityColumn);
-
-                        if (p.CanWrite)
-                            p.SetValue(items[counter], reader[0], null);
-
-                        else
-                            throw new SqlBulkToolsException(GetPrivateSetterExceptionMessage(identityColumn));
-
-                        counter++;
-                    }
-                }
-
-                command.CommandText = GetDropTmpTableCmd();
-                command.ExecuteNonQuery();
-            }
-        }
-
-        internal static async Task LoadFromTmpOutputTableAsync<T>(SqlCommand command, string identityColumn,
-            Dictionary<int, T> outputIdentityDic, OperationType operationType, IEnumerable<T> list)
-        {
-            if (operationType == OperationType.InsertOrUpdate
-                || operationType == OperationType.Update
-                || operationType == OperationType.Delete)
-            {
-                command.CommandText = "SELECT " + Constants.InternalId + ", " + identityColumn + " FROM "
-                    + Constants.TempOutputTableName + ";";
-
-                using (SqlDataReader reader = await command.ExecuteReaderAsync())
-                {
-                    while (reader.Read())
-                    {
-                        T item;
-
-                        if (outputIdentityDic.TryGetValue((int)reader[0], out item))
-                        {
-                            PropertyInfo p = item.GetType().GetProperty(identityColumn);
-
-                            if (p.CanWrite)
-                                p.SetValue(item, reader[1], null);
-
-                            else
-                                throw new SqlBulkToolsException(GetPrivateSetterExceptionMessage(identityColumn));
-                        }
-
-                    }
-                }
-
-                command.CommandText = GetDropTmpTableCmd();
-                await command.ExecuteNonQueryAsync();
-            }
-
-            if (operationType == OperationType.Insert)
-            {
-                command.CommandText = "SELECT " + identityColumn + " FROM " + Constants.TempOutputTableName + ";";
-
-                using (SqlDataReader reader = await command.ExecuteReaderAsync())
-                {
-                    var items = list.ToList();
-                    int counter = 0;
-
-                    while (reader.Read())
-                    {
-                        PropertyInfo p = items[counter].GetType().GetProperty(identityColumn);
-
-                        if (p.CanWrite)
-                            p.SetValue(items[counter], reader[0], null);
-
-                        else
-                            throw new SqlBulkToolsException(GetPrivateSetterExceptionMessage(identityColumn));
-
-                        counter++;
-                    }
-                }
-
-                command.CommandText = GetDropTmpTableCmd();
-                await command.ExecuteNonQueryAsync();
-            }
-        }
-
-        private static string GetPrivateSetterExceptionMessage(string columnName)
-        {
-            return $"No setter method available on property '{columnName}'. Could not write output back to property.";
-        }
-
-        internal static string GetInsertIntoStagingTableCmd(SqlCommand command, SqlConnection conn, string schema, string tableName,
-            HashSet<string> columns, string identityColumn, ColumnDirection outputIdentity)
-        {
-
-            string fullTableName = GetFullQualifyingTableName(conn.Database, schema,
-                tableName);
-
-            string comm =
-            GetOutputCreateTableCmd(outputIdentity, Constants.TempOutputTableName,
-            OperationType.Insert, identityColumn) +
-            BuildInsertIntoSet(columns, identityColumn, fullTableName)
-            + "OUTPUT INSERTED.[" + identityColumn + "] INTO "
-            + Constants.TempOutputTableName + "([" + identityColumn + "]) "
-            + BuildSelectSet(columns, Constants.SourceAlias, identityColumn)
-            + " FROM " + Constants.TempTableName + " AS Source; " +
-            "DROP TABLE " + Constants.TempTableName + ";";
-
-            return comm;
-        }
-
-        /// <summary>
-        /// 
-        /// </summary>
-        /// <param name="predicate"></param>
-        /// <param name="predicateType"></param>
-        /// <param name="predicateList"></param>
-        /// <param name="sqlParamsList"></param>
-        /// <param name="sortOrder"></param>
-        /// <param name="appendParam"></param>
-        internal static void AddPredicate<T>(Expression<Func<T, bool>> predicate, PredicateType predicateType, List<Condition> predicateList, 
-            List<SqlParameter> sqlParamsList, int sortOrder, string appendParam)
-        {
-            string leftName;
-            string value;
-            Condition condition;
-
-            BinaryExpression binaryBody = predicate.Body as BinaryExpression;
-
-            if (binaryBody == null)
+	internal static class BulkOperationsHelper
+	{
+
+		internal struct PrecisionType
+		{
+			public string NumericPrecision { get; set; }
+			public string NumericScale { get; set; }
+		}
+
+		internal static string BuildCreateTempTable( HashSet<string> columns, DataTable schema, ColumnDirection outputIdentity )
+		{
+			Dictionary<string, string> actualColumns = new Dictionary<string, string>();
+			Dictionary<string, string> actualColumnsMaxCharLength = new Dictionary<string, string>();
+			Dictionary<string, PrecisionType> actualColumnsNumericPrecision = new Dictionary<string, PrecisionType>();
+			Dictionary<string, string> actualColumnsDateTimePrecision = new Dictionary<string, string>();
+
+
+			foreach ( DataRow row in schema.Rows )
+			{
+				string columnType = row["DATA_TYPE"].ToString();
+				string columnName = row["COLUMN_NAME"].ToString();
+
+				actualColumns.Add( row["COLUMN_NAME"].ToString(), row["DATA_TYPE"].ToString() );
+
+				if ( columnType == "varchar" || columnType == "nvarchar" ||
+					columnType == "char" || columnType == "binary" ||
+					columnType == "varbinary" || columnType == "nchar" )
+
+				{
+					actualColumnsMaxCharLength.Add( row["COLUMN_NAME"].ToString(),
+						row["CHARACTER_MAXIMUM_LENGTH"].ToString() );
+				}
+
+				if ( columnType == "datetime2" || columnType == "time" )
+				{
+					actualColumnsDateTimePrecision.Add( row["COLUMN_NAME"].ToString(), row["DATETIME_PRECISION"].ToString() );
+				}
+
+				if ( columnType == "numeric" || columnType == "decimal" )
+				{
+					PrecisionType p = new PrecisionType
+					{
+						NumericPrecision = row["NUMERIC_PRECISION"].ToString(),
+						NumericScale = row["NUMERIC_SCALE"].ToString()
+					};
+					actualColumnsNumericPrecision.Add( columnName, p );
+				}
+
+			}
+
+			StringBuilder command = new StringBuilder();
+
+			command.Append( "CREATE TABLE " + Constants.TempTableName + "(" );
+
+			List<string> paramList = new List<string>();
+
+			foreach ( var column in columns.ToList() )
+			{
+				if ( column == Constants.InternalId )
+					continue;
+				string columnType;
+				if ( actualColumns.TryGetValue( column, out columnType ) )
+				{
+					columnType = GetVariableCharType( column, columnType, actualColumnsMaxCharLength );
+					columnType = GetDecimalPrecisionAndScaleType( column, columnType, actualColumnsNumericPrecision );
+					columnType = GetDateTimePrecisionType( column, columnType, actualColumnsDateTimePrecision );
+				}
+
+				paramList.Add( "[" + column + "]" + " " + columnType );
+			}
+
+			string paramListConcatenated = string.Join( ", ", paramList );
+
+			command.Append( paramListConcatenated );
+
+			if ( outputIdentity == ColumnDirection.InputOutput )
+			{
+				command.Append( ", [" + Constants.InternalId + "] int" );
+			}
+			command.Append( ");" );
+
+			return command.ToString();
+		}
+
+		private static string GetVariableCharType( string column, string columnType, Dictionary<string, string> actualColumnsMaxCharLength )
+		{
+			if ( columnType == "varchar" || columnType == "nvarchar" ||
+					columnType == "char" || columnType == "binary" ||
+					columnType == "varbinary" || columnType == "nchar" )
+			{
+				string maxCharLength;
+				if ( actualColumnsMaxCharLength.TryGetValue( column, out maxCharLength ) )
+				{
+					if ( maxCharLength == "-1" )
+						maxCharLength = "max";
+
+					columnType = columnType + "(" + maxCharLength + ")";
+				}
+			}
+
+			return columnType;
+		}
+
+		private static string GetDecimalPrecisionAndScaleType( string column, string columnType, Dictionary<string, PrecisionType> actualColumnsPrecision )
+		{
+			if ( columnType == "decimal" || columnType == "numeric" )
+			{
+				PrecisionType p;
+
+				if ( actualColumnsPrecision.TryGetValue( column, out p ) )
+				{
+					columnType = columnType + "(" + p.NumericPrecision + ", " + p.NumericScale + ")";
+				}
+			}
+
+			return columnType;
+		}
+
+		private static string GetDateTimePrecisionType( string column, string columnType, Dictionary<string, string> actualColumnsDateTimePrecision )
+		{
+			if ( columnType == "datetime2" || columnType == "time" )
+			{
+				string dateTimePrecision;
+				if ( actualColumnsDateTimePrecision.TryGetValue( column, out dateTimePrecision ) )
+				{
+
+					columnType = columnType + "(" + dateTimePrecision + ")";
+				}
+			}
+
+			return columnType;
+		}
+
+		internal static string BuildJoinConditionsForUpdateOrInsert( string[] updateOn, string sourceAlias, string targetAlias )
+		{
+			StringBuilder command = new StringBuilder();
+
+			command.Append( "ON " + "[" + targetAlias + "]" + "." + "[" + updateOn[0] + "]" + " = " + "[" + sourceAlias + "]" + "."
+				+ "[" + updateOn[0] + "]" + " " );
+
+			if ( updateOn.Length > 1 )
+			{
+				// Start from index 1 to just append "AND" conditions
+				for ( int i = 1; i < updateOn.Length; i++ )
+				{
+					command.Append( "AND " + "[" + targetAlias + "]" + "." + "[" + updateOn[i] + "]" + " = " + "[" +
+						sourceAlias + "]" + "." + "[" + updateOn[i] + "]" + " " );
+				}
+			}
+
+			return command.ToString();
+		}
+
+		internal static string BuildPredicateQuery( string[] updateOn, IEnumerable<Condition> conditions, string targetAlias )
+		{
+			if ( conditions == null )
+				return null;
+
+			if ( updateOn == null || updateOn.Length == 0 )
+				throw new SqlBulkToolsException( "MatchTargetOn is required for AndQuery." );
+
+			StringBuilder command = new StringBuilder();
+
+			foreach ( var condition in conditions )
+			{
+				string targetColumn = condition.CustomColumnMapping ?? condition.LeftName;
+
+				command.Append( "AND [" + targetAlias + "].[" + targetColumn + "] " +
+							   GetOperator( condition ) + " " + ( condition.Value != "NULL" ? ( "@" +
+							   condition.LeftName + Constants.UniqueParamIdentifier + condition.SortOrder ) : "NULL" ) + " " );
+			}
+
+			return command.ToString();
+
+		}
+
+		// Used for UpdateQuery and DeleteQuery where, and, or conditions. 
+		internal static string BuildPredicateQuery( IEnumerable<Condition> conditions )
+		{
+			if ( conditions == null )
+				return null;
+
+			conditions = conditions.OrderBy( x => x.SortOrder );
+
+			StringBuilder command = new StringBuilder();
+
+			foreach ( var condition in conditions )
+			{
+				string targetColumn = condition.CustomColumnMapping ?? condition.LeftName;
+
+				switch ( condition.PredicateType )
+				{
+					case PredicateType.Where:
+						{
+							command.Append( " WHERE " );
+							break;
+						}
+
+					case PredicateType.And:
+						{
+							command.Append( " AND " );
+							break;
+						}
+
+					case PredicateType.Or:
+						{
+							command.Append( " OR " );
+							break;
+						}
+
+					default:
+						{
+							throw new KeyNotFoundException( "Predicate not found" );
+						}
+				}
+
+				command.Append( "[" + targetColumn + "] " +
+							   GetOperator( condition ) + " " + ( condition.Value != "NULL" ? ( "@" + condition.LeftName + Constants.UniqueParamIdentifier + condition.SortOrder ) : "NULL" ) );
+			}
+
+			return command.ToString();
+
+		}
+
+		internal static string GetOperator( Condition condition )
+		{
+			switch ( condition.Expression )
+			{
+				case ExpressionType.NotEqual:
+					{
+						if ( condition.ValueType == null )
+						{
+							condition.Value = condition.Value?.ToUpper();
+							return "IS NOT";
+						}
+
+						return "!=";
+					}
+				case ExpressionType.Equal:
+					{
+						if ( condition.ValueType == null )
+						{
+							condition.Value = condition.Value?.ToUpper();
+							return "IS";
+						}
+
+						return "=";
+					}
+				case ExpressionType.LessThan:
+					{
+						return "<";
+					}
+				case ExpressionType.LessThanOrEqual:
+					{
+						return "<=";
+					}
+				case ExpressionType.GreaterThan:
+					{
+						return ">";
+					}
+				case ExpressionType.GreaterThanOrEqual:
+					{
+						return ">=";
+					}
+			}
+
+			throw new SqlBulkToolsException( "ExpressionType not found when trying to map logical operator." );
+
+		}
+
+		internal static string BuildUpdateSet( HashSet<string> columns, string sourceAlias, string targetAlias, string identityColumn )
+		{
+			StringBuilder command = new StringBuilder();
+			List<string> paramsSeparated = new List<string>();
+
+			command.Append( "SET " );
+
+			foreach ( var column in columns.ToList() )
+			{
+				if ( identityColumn != null && column != identityColumn || identityColumn == null )
+				{
+					if ( column != Constants.InternalId )
+						paramsSeparated.Add( "[" + targetAlias + "]" + "." + "[" + column + "]" + " = " + "[" + sourceAlias + "]" + "."
+							+ "[" + column + "]" );
+				}
+			}
+
+			command.Append( string.Join( ", ", paramsSeparated ) + " " );
+
+			return command.ToString();
+		}
+
+		/// <summary>
+		/// Specificially for UpdateQuery and DeleteQuery
+		/// </summary>
+		/// <param name="columns"></param>
+		/// <param name="fullQualifiedTableName"></param>
+		/// <returns></returns>
+		internal static string BuildUpdateSet( HashSet<string> columns, string fullQualifiedTableName )
+		{
+			StringBuilder command = new StringBuilder();
+			List<string> paramsSeparated = new List<string>();
+
+			command.Append( "SET " );
+
+			foreach ( var column in columns.ToList() )
+			{
+				paramsSeparated.Add( fullQualifiedTableName + "." + "[" + column + "]" + " = @" + column );
+			}
+
+			command.Append( string.Join( ", ", paramsSeparated ) );
+
+			return command.ToString();
+		}
+
+		internal static string BuildInsertSet( HashSet<string> columns, string sourceAlias, string identityColumn )
+		{
+			StringBuilder command = new StringBuilder();
+			List<string> insertColumns = new List<string>();
+			List<string> values = new List<string>();
+
+			command.Append( "INSERT (" );
+
+			foreach ( var column in columns.ToList() )
+			{
+
+				if ( column != Constants.InternalId && column != identityColumn )
+				{
+					insertColumns.Add( "[" + column + "]" );
+					values.Add( "[" + sourceAlias + "]" + "." + "[" + column + "]" );
+				}
+
+			}
+
+			command.Append( string.Join( ", ", insertColumns ) );
+			command.Append( ") values (" );
+			command.Append( string.Join( ", ", values ) );
+			command.Append( ")" );
+
+			return command.ToString();
+		}
+
+		internal static string BuildInsertIntoSet( HashSet<string> columns, string identityColumn, string tableName )
+		{
+			StringBuilder command = new StringBuilder();
+			List<string> insertColumns = new List<string>();
+
+			command.Append( "INSERT INTO " );
+			command.Append( tableName );
+			command.Append( " (" );
+
+			foreach ( var column in columns )
+			{
+				if ( column != Constants.InternalId && column != identityColumn )
+					insertColumns.Add( "[" + column + "]" );
+			}
+
+			command.Append( string.Join( ", ", insertColumns ) );
+			command.Append( ") " );
+
+			return command.ToString();
+		}
+
+		internal static string BuildSelectSet( HashSet<string> columns, string sourceAlias, string identityColumn )
+		{
+			StringBuilder command = new StringBuilder();
+			List<string> selectColumns = new List<string>();
+			List<string> values = new List<string>();
+
+			command.Append( "SELECT " );
+
+			foreach ( var column in columns.ToList() )
+			{
+				if ( identityColumn != null && column != identityColumn || identityColumn == null )
+				{
+					if ( column != Constants.InternalId )
+					{
+						selectColumns.Add( "[" + sourceAlias + "].[" + column + "]" );
+						values.Add( "[" + column + "]" );
+					}
+				}
+			}
+
+			command.Append( string.Join( ", ", selectColumns ) );
+
+			return command.ToString();
+		}
+
+		internal static string GetPropertyName( Expression method )
+		{
+			LambdaExpression lambda = method as LambdaExpression;
+			if ( lambda == null )
+				throw new ArgumentNullException( "method" );
+
+			MemberExpression memberExpr = null;
+
+			if ( lambda.Body.NodeType == ExpressionType.Convert )
+			{
+				memberExpr =
+					( (UnaryExpression)lambda.Body ).Operand as MemberExpression;
+			}
+			else if ( lambda.Body.NodeType == ExpressionType.MemberAccess )
+			{
+				memberExpr = lambda.Body as MemberExpression;
+			}
+
+			if ( memberExpr == null )
+				throw new ArgumentException( "method" );
+
+			return memberExpr.Member.Name;
+		}
+
+		internal static DataTable CreateDataTable<T>( HashSet<string> columns, Dictionary<string, string> columnMappings,
+			List<string> matchOnColumns = null, ColumnDirection? outputIdentity = null )
+		{
+			if ( columns == null )
+				return null;
+
+			DataTable dataTable = new DataTable( typeof( T ).Name );
+
+			if ( matchOnColumns != null )
+			{
+				columns = CheckForAdditionalColumns( columns, matchOnColumns );
+			}
+
+			if ( outputIdentity.HasValue && outputIdentity.Value == ColumnDirection.InputOutput )
+			{
+				columns.Add( Constants.InternalId );
+			}
+
+			//Get all the properties
+			PropertyInfo[] props = typeof( T ).GetProperties( BindingFlags.Public | BindingFlags.Instance );
+
+			foreach ( var column in columns.ToList() )
+			{
+				if ( columnMappings != null && columnMappings.ContainsKey( column ) )
+				{
+					dataTable.Columns.Add( columnMappings[column] );
+				}
+
+				else
+					dataTable.Columns.Add( column );
+			}
+
+			AssignTypes( props, columns, dataTable );
+
+			return dataTable;
+		}
+
+		public static DataTable ConvertListToDataTable<T>( DataTable dataTable, IEnumerable<T> list, HashSet<string> columns,
+			Dictionary<int, T> outputIdentityDic = null )
+		{
+
+			PropertyInfo[] props = typeof( T ).GetProperties( BindingFlags.Public | BindingFlags.Instance );
+
+			int counter = 0;
+
+			foreach ( T item in list )
+			{
+
+				var values = new List<object>();
+
+				foreach ( var column in columns.ToList() )
+				{
+					if ( column == Constants.InternalId )
+					{
+						values.Add( counter );
+						outputIdentityDic?.Add( counter, item );
+					}
+					else
+						for ( int i = 0; i < props.Length; i++ )
+						{
+							if ( props[i].Name == column && item != null
+								&& CheckForValidDataType( props[i].PropertyType, throwIfInvalid: true ) )
+								values.Add( props[i].GetValue( item, null ) );
+
+
+						}
+
+				}
+				counter++;
+				dataTable.Rows.Add( values.ToArray() );
+
+			}
+			return dataTable;
+
+		}
+
+		// Loops through object properties, checks if column has been added, adds as sql parameter. Used for the UpdateQuery method. 
+		public static void AddSqlParamsForUpdateQuery<T>( List<SqlParameter> sqlParameters, HashSet<string> columns, T item )
+		{
+			PropertyInfo[] props = typeof( T ).GetProperties( BindingFlags.Public | BindingFlags.Instance );
+
+			foreach ( var column in columns.ToList() )
+			{
+				for ( int i = 0; i < props.Length; i++ )
+				{
+					if ( props[i].Name == column && item != null && CheckForValidDataType( props[i].PropertyType, throwIfInvalid: true ) )
+					{
+						DbType sqlType = SqlTypeMap.GetSqlTypeFromNetType( props[i].PropertyType );
+						SqlParameter param = new SqlParameter( $"@{column}", sqlType );
+						param.Value = props[i].GetValue( item, null );
+
+						sqlParameters.Add( param );
+					}
+				}
+			}
+		}
+
+		/// <summary>
+		/// 
+		/// </summary>
+		/// <param name="type"></param>
+		/// <param name="throwIfInvalid">
+		/// Set this to true if user is manually adding columns. If AddAllColumns is used, then this can be omitted. 
+		/// </param>
+		/// <returns></returns>
+		private static bool CheckForValidDataType( Type type, bool throwIfInvalid = false )
+		{
+			if ( type.IsValueType ||
+				type == typeof( string ) ||
+				type == typeof( byte[] ) ||
+				type == typeof( char[] ) ||
+				type == typeof( SqlXml )
+				)
+				return true;
+
+			if ( throwIfInvalid )
+				throw new SqlBulkToolsException( "Only value, string, char[], byte[] " +
+													"and SqlXml types can be used with SqlBulkTools. " +
+													"Refer to https://msdn.microsoft.com/en-us/library/cc716729(v=vs.110).aspx for more details." );
+
+			return false;
+		}
+
+		private static void AssignTypes( PropertyInfo[] props, HashSet<string> columns, DataTable dataTable )
+		{
+			int count = 0;
+
+			foreach ( var column in columns.ToList() )
+			{
+				if ( column == Constants.InternalId )
+				{
+					dataTable.Columns[count].DataType = typeof( int );
+				}
+				else
+					for ( int i = 0; i < props.Length; i++ )
+					{
+						if ( props[i].Name == column )
+						{
+							dataTable.Columns[count].DataType = Nullable.GetUnderlyingType( props[i].PropertyType ) ??
+																props[i].PropertyType;
+						}
+					}
+				count++;
+			}
+		}
+
+		internal static SqlConnection GetSqlConnection( string connectionName, SqlCredential credentials, SqlConnection connection )
+		{
+			SqlConnection conn = null;
+
+			if ( connection != null )
+			{
+				conn = connection;
+				return conn;
+			}
+
+			if ( connectionName != null )
+			{
+				conn = new SqlConnection( ConfigurationManager
+					.ConnectionStrings[connectionName].ConnectionString, credentials );
+				return conn;
+			}
+
+			throw new SqlBulkToolsException( "Could not create SQL connection. Please check your arguments into CommitTransaction" );
+		}
+
+		internal static string GetFullQualifyingTableName( string databaseName, string schemaName, string tableName )
+		{
+			StringBuilder sb = new StringBuilder();
+			sb.Append( "[" );
+			sb.Append( databaseName );
+			sb.Append( "].[" );
+			sb.Append( schemaName );
+			sb.Append( "].[" );
+			sb.Append( tableName );
+			sb.Append( "]" );
+
+			return sb.ToString();
+		}
+
+
+		/// <summary>
+		/// If there are MatchOnColumns that don't exist in columns, add to columns.
+		/// </summary>
+		/// <param name="columns"></param>
+		/// <param name="matchOnColumns"></param>
+		/// <returns></returns>
+		internal static HashSet<string> CheckForAdditionalColumns( HashSet<string> columns, List<string> matchOnColumns )
+		{
+			foreach ( var col in matchOnColumns )
+			{
+				if ( !columns.Contains( col ) )
+				{
+					columns.Add( col );
+				}
+			}
+
+			return columns;
+		}
+
+		internal static void DoColumnMappings( Dictionary<string, string> columnMappings, HashSet<string> columns,
+		List<string> updateOnList )
+		{
+			if ( columnMappings.Count > 0 )
+			{
+				foreach ( var column in columnMappings )
+				{
+					if ( columns.Contains( column.Key ) )
+					{
+						columns.Remove( column.Key );
+						columns.Add( column.Value );
+					}
+
+					for ( int i = 0; i < updateOnList.ToArray().Length; i++ )
+					{
+						if ( updateOnList[i] == column.Key )
+						{
+							updateOnList[i] = column.Value;
+						}
+					}
+				}
+			}
+		}
+
+		internal static void DoColumnMappings( Dictionary<string, string> columnMappings, HashSet<string> columns )
+		{
+			if ( columnMappings.Count > 0 )
+			{
+				foreach ( var column in columnMappings )
+				{
+					if ( columns.Contains( column.Key ) )
+					{
+						columns.Remove( column.Key );
+						columns.Add( column.Value );
+					}
+				}
+			}
+		}
+
+		internal static void DoColumnMappings( Dictionary<string, string> columnMappings, List<Condition> predicateConditions )
+		{
+			foreach ( var condition in predicateConditions )
+			{
+				string columnName;
+
+				if ( columnMappings.TryGetValue( condition.LeftName, out columnName ) )
+				{
+					condition.CustomColumnMapping = columnName;
+				}
+			}
+		}
+
+		/// <summary>
+		/// Advanced Settings for SQLBulkCopy class. 
+		/// </summary>
+		/// <param name="bulkcopy"></param>
+		/// <param name="bulkCopyEnableStreaming"></param>
+		/// <param name="bulkCopyBatchSize"></param>
+		/// <param name="bulkCopyNotifyAfter"></param>
+		/// <param name="bulkCopyTimeout"></param>
+		/// <param name="bulkCopyDelegates"></param>
+		internal static void SetSqlBulkCopySettings( SqlBulkCopy bulkcopy, bool bulkCopyEnableStreaming, int? bulkCopyBatchSize,
+			int? bulkCopyNotifyAfter, int bulkCopyTimeout, IEnumerable<SqlRowsCopiedEventHandler> bulkCopyDelegates )
+		{
+			bulkcopy.EnableStreaming = bulkCopyEnableStreaming;
+
+			if ( bulkCopyBatchSize.HasValue )
+			{
+				bulkcopy.BatchSize = bulkCopyBatchSize.Value;
+			}
+
+			if ( bulkCopyNotifyAfter.HasValue )
+			{
+				bulkcopy.NotifyAfter = bulkCopyNotifyAfter.Value;
+				bulkCopyDelegates?.ToList().ForEach( x => bulkcopy.SqlRowsCopied += x );
+			}
+
+			bulkcopy.BulkCopyTimeout = bulkCopyTimeout;
+		}
+
+
+		/// <summary>
+		/// This is used only for the BulkInsert method at this time.  
+		/// </summary>
+		/// <param name="bulkCopy"></param>
+		/// <param name="columns"></param>
+		/// <param name="customColumnMappings"></param>
+		internal static void MapColumns( SqlBulkCopy bulkCopy, HashSet<string> columns, Dictionary<string, string> customColumnMappings )
+		{
+
+			foreach ( var column in columns.ToList() )
+			{
+				string mapping;
+
+				if ( customColumnMappings.TryGetValue( column, out mapping ) )
+				{
+					bulkCopy.ColumnMappings.Add( mapping, mapping );
+				}
+
+				else
+					bulkCopy.ColumnMappings.Add( column, column );
+			}
+
+		}
+
+		internal static HashSet<string> GetAllValueTypeAndStringColumns( Type type )
+		{
+			HashSet<string> columns = new HashSet<string>();
+
+			//Get all the properties
+			PropertyInfo[] props = type.GetProperties( BindingFlags.Public | BindingFlags.Instance );
+
+			for ( int i = 0; i < props.Length; i++ )
+			{
+				if ( CheckForValidDataType( props[i].PropertyType ) )
+				{
+					columns.Add( props[i].Name );
+				}
+			}
+
+			return columns;
+
+		}
+
+		internal static string GetOutputIdentityCmd( string identityColumn, ColumnDirection outputIdentity, string tmpTableName, OperationType operation )
+		{
+
+			StringBuilder sb = new StringBuilder();
+			if ( identityColumn == null || outputIdentity != ColumnDirection.InputOutput )
+			{
+				return null;
+			}
+			if ( operation == OperationType.Insert )
+				sb.Append( "OUTPUT INSERTED." + identityColumn + " INTO " + tmpTableName + "(" + identityColumn + "); " );
+
+			else if ( operation == OperationType.InsertOrUpdate || operation == OperationType.Update )
+				sb.Append( "OUTPUT Source." + Constants.InternalId + ", INSERTED." + identityColumn + " INTO " + tmpTableName
+					+ "(" + Constants.InternalId + ", " + identityColumn + "); " );
+
+			else if ( operation == OperationType.Delete )
+				sb.Append( "OUTPUT Source." + Constants.InternalId + ", DELETED." + identityColumn + " INTO " + tmpTableName
+					+ "(" + Constants.InternalId + ", " + identityColumn + "); " );
+
+			return sb.ToString();
+		}
+
+		internal static string GetOutputCreateTableCmd( ColumnDirection outputIdentity, string tmpTablename, OperationType operation, string identityColumn )
+		{
+
+			if ( operation == OperationType.Insert )
+				return ( outputIdentity == ColumnDirection.InputOutput ? "CREATE TABLE " + tmpTablename + "(" + "[" + identityColumn + "] int); " : "" );
+
+			else if ( operation == OperationType.InsertOrUpdate || operation == OperationType.Update || operation == OperationType.Delete )
+				return ( outputIdentity == ColumnDirection.InputOutput ? "CREATE TABLE " + tmpTablename + "("
+					+ "[" + Constants.InternalId + "]" + " int, [" + identityColumn + "] int); " : "" );
+
+			return string.Empty;
+		}
+
+		internal static string GetDropTmpTableCmd()
+		{
+			return "DROP TABLE " + Constants.TempOutputTableName + ";";
+		}
+
+		internal static string GetIndexManagementCmd( string action, string tableName,
+			string schema, IDbConnection conn, HashSet<string> disableIndexList, bool disableAllIndexes = false )
+		{
+			StringBuilder sb = new StringBuilder();
+
+			if ( disableIndexList != null && disableIndexList.Any() )
+			{
+				foreach ( var index in disableIndexList )
+				{
+					sb.Append( " AND sys.indexes.name = \'" );
+					sb.Append( index );
+					sb.Append( "\'" );
+				}
+			}
+
+			string cmd = "DECLARE @sql AS VARCHAR(MAX)=''; " +
+								"SELECT @sql = @sql + " +
+								"'ALTER INDEX ' + sys.indexes.name + ' ON ' + sys.objects.name + ' " + action + ";' " +
+								"FROM sys.indexes JOIN sys.objects ON sys.indexes.object_id = sys.objects.object_id " +
+								"WHERE sys.indexes.type_desc = 'NONCLUSTERED' " +
+								"AND sys.objects.type_desc = 'USER_TABLE' " +
+								"AND sys.objects.name = '" + GetFullQualifyingTableName( conn.Database, schema, tableName )
+								+ "'" + ( sb.Length > 0 ? sb.ToString() : "" ) + "; EXEC(@sql);";
+
+			return cmd;
+		}
+
+		/// <summary>
+		/// Gets schema information for a table. Used to get SQL type of property. 
+		/// </summary>
+		/// <param name="conn"></param>
+		/// <param name="schema"></param>
+		/// <param name="tableName"></param>
+		/// <param name="transaction"></param>
+		/// <returns></returns>
+		internal static DataTable GetDatabaseSchema( SqlConnection conn, string schema, string tableName, SqlTransaction transaction )
+		{
+			string[] restrictions = new string[4];
+			restrictions[0] = conn.Database;
+			restrictions[1] = schema;
+			restrictions[2] = tableName;
+			DataTable dtCols;
+			const string columnsCollectionName = "Columns";
+			if ( transaction != null )
+			{
+				// Calling GetSchema on a SqlConnection associated with a transaction may throw an exception. So if a transaction
+				// is provided then creating a new SqlConnection w/o a transaction to get the schema
+				// https://msdn.microsoft.com/en-us/library/system.data.common.dbconnection.getschema.aspx?f=255&MSPPError=-2147217396
+				using ( SqlConnection untransactedConnection = new SqlConnection( conn.ConnectionString, conn.Credential ) )
+				{
+					untransactedConnection.Open();
+					dtCols = untransactedConnection.GetSchema( columnsCollectionName, restrictions );
+				}
+			}
+			else
+			{
+				dtCols = conn.GetSchema( columnsCollectionName, restrictions );
+			}
+
+			if ( dtCols.Rows.Count == 0 && schema != null )
+				throw new SqlBulkToolsException( "Table name '" + tableName
+				+ "\' with schema name \'" + schema + "\' not found. Check your setup and try again." );
+
+			if ( dtCols.Rows.Count == 0 )
+				throw new SqlBulkToolsException( "Table name \'" + tableName
+				+ "\' not found. Check your setup and try again." );
+			return dtCols;
+		}
+
+		internal static void InsertToTmpTable( SqlConnection conn, SqlTransaction transaction, DataTable dt, bool bulkCopyEnableStreaming,
+			int? bulkCopyBatchSize, int? bulkCopyNotifyAfter, int bulkCopyTimeout, SqlBulkCopyOptions sqlBulkCopyOptions, IEnumerable<SqlRowsCopiedEventHandler> bulkCopyDelegates )
+		{
+			using ( SqlBulkCopy bulkcopy = new SqlBulkCopy( conn, sqlBulkCopyOptions, transaction ) )
+			{
+				bulkcopy.DestinationTableName = Constants.TempTableName;
+
+				SetSqlBulkCopySettings( bulkcopy, bulkCopyEnableStreaming,
+					bulkCopyBatchSize,
+					bulkCopyNotifyAfter, bulkCopyTimeout, bulkCopyDelegates );
+
+				bulkcopy.WriteToServer( dt );
+			}
+		}
+
+		internal static async Task InsertToTmpTableAsync( SqlConnection conn, SqlTransaction transaction, DataTable dt, bool bulkCopyEnableStreaming,
+			int? bulkCopyBatchSize, int? bulkCopyNotifyAfter, int bulkCopyTimeout, SqlBulkCopyOptions sqlBulkCopyOptions, IEnumerable<SqlRowsCopiedEventHandler> bulkCopyDelegates )
+		{
+			using ( SqlBulkCopy bulkcopy = new SqlBulkCopy( conn, sqlBulkCopyOptions, transaction ) )
+			{
+				bulkcopy.DestinationTableName = Constants.TempTableName;
+
+				SetSqlBulkCopySettings( bulkcopy, bulkCopyEnableStreaming,
+					bulkCopyBatchSize,
+					bulkCopyNotifyAfter, bulkCopyTimeout, bulkCopyDelegates );
+
+				await bulkcopy.WriteToServerAsync( dt );
+			}
+		}
+
+		internal static void LoadFromTmpOutputTable<T>( SqlCommand command, string identityColumn, Dictionary<int, T> outputIdentityDic,
+			OperationType operationType, IEnumerable<T> list )
+		{
+			if ( operationType == OperationType.InsertOrUpdate
+				|| operationType == OperationType.Update
+				|| operationType == OperationType.Delete )
+			{
+				command.CommandText = "SELECT " + Constants.InternalId + ", " + identityColumn + " FROM "
+					+ Constants.TempOutputTableName + ";";
+
+				using ( SqlDataReader reader = command.ExecuteReader() )
+				{
+					while ( reader.Read() )
+					{
+						T item;
+
+						if ( outputIdentityDic.TryGetValue( (int)reader[0], out item ) )
+						{
+							PropertyInfo p = item.GetType().GetProperty( identityColumn );
+
+							if ( p.CanWrite )
+								p.SetValue( item, reader[1], null );
+
+							else
+								throw new SqlBulkToolsException( GetPrivateSetterExceptionMessage( identityColumn ) );
+						}
+
+					}
+				}
+
+				command.CommandText = GetDropTmpTableCmd();
+				command.ExecuteNonQuery();
+			}
+
+			if ( operationType == OperationType.Insert )
+			{
+				command.CommandText = "SELECT " + identityColumn + " FROM " + Constants.TempOutputTableName + ";";
+
+				using ( SqlDataReader reader = command.ExecuteReader() )
+				{
+					var items = list.ToList();
+					int counter = 0;
+
+					while ( reader.Read() )
+					{
+						PropertyInfo p = items[counter].GetType().GetProperty( identityColumn );
+
+						if ( p.CanWrite )
+							p.SetValue( items[counter], reader[0], null );
+
+						else
+							throw new SqlBulkToolsException( GetPrivateSetterExceptionMessage( identityColumn ) );
+
+						counter++;
+					}
+				}
+
+				command.CommandText = GetDropTmpTableCmd();
+				command.ExecuteNonQuery();
+			}
+		}
+
+		internal static async Task LoadFromTmpOutputTableAsync<T>( SqlCommand command, string identityColumn,
+			Dictionary<int, T> outputIdentityDic, OperationType operationType, IEnumerable<T> list )
+		{
+			if ( operationType == OperationType.InsertOrUpdate
+				|| operationType == OperationType.Update
+				|| operationType == OperationType.Delete )
+			{
+				command.CommandText = "SELECT " + Constants.InternalId + ", " + identityColumn + " FROM "
+					+ Constants.TempOutputTableName + ";";
+
+				using ( SqlDataReader reader = await command.ExecuteReaderAsync() )
+				{
+					while ( reader.Read() )
+					{
+						T item;
+
+						if ( outputIdentityDic.TryGetValue( (int)reader[0], out item ) )
+						{
+							PropertyInfo p = item.GetType().GetProperty( identityColumn );
+
+							if ( p.CanWrite )
+								p.SetValue( item, reader[1], null );
+
+							else
+								throw new SqlBulkToolsException( GetPrivateSetterExceptionMessage( identityColumn ) );
+						}
+
+					}
+				}
+
+				command.CommandText = GetDropTmpTableCmd();
+				await command.ExecuteNonQueryAsync();
+			}
+
+			if ( operationType == OperationType.Insert )
+			{
+				command.CommandText = "SELECT " + identityColumn + " FROM " + Constants.TempOutputTableName + ";";
+
+				using ( SqlDataReader reader = await command.ExecuteReaderAsync() )
+				{
+					var items = list.ToList();
+					int counter = 0;
+
+					while ( reader.Read() )
+					{
+						PropertyInfo p = items[counter].GetType().GetProperty( identityColumn );
+
+						if ( p.CanWrite )
+							p.SetValue( items[counter], reader[0], null );
+
+						else
+							throw new SqlBulkToolsException( GetPrivateSetterExceptionMessage( identityColumn ) );
+
+						counter++;
+					}
+				}
+
+				command.CommandText = GetDropTmpTableCmd();
+				await command.ExecuteNonQueryAsync();
+			}
+		}
+
+		private static string GetPrivateSetterExceptionMessage( string columnName )
+		{
+			return $"No setter method available on property '{columnName}'. Could not write output back to property.";
+		}
+
+		internal static string GetInsertIntoStagingTableCmd( SqlCommand command, SqlConnection conn, string schema, string tableName,
+			HashSet<string> columns, string identityColumn, ColumnDirection outputIdentity )
+		{
+
+			string fullTableName = GetFullQualifyingTableName( conn.Database, schema,
+				tableName );
+
+			string comm =
+			GetOutputCreateTableCmd( outputIdentity, Constants.TempOutputTableName,
+			OperationType.Insert, identityColumn ) +
+			BuildInsertIntoSet( columns, identityColumn, fullTableName )
+			+ "OUTPUT INSERTED.[" + identityColumn + "] INTO "
+			+ Constants.TempOutputTableName + "([" + identityColumn + "]) "
+			+ BuildSelectSet( columns, Constants.SourceAlias, identityColumn )
+			+ " FROM " + Constants.TempTableName + " AS Source; " +
+			"DROP TABLE " + Constants.TempTableName + ";";
+
+			return comm;
+		}
+
+		/// <summary>
+		/// 
+		/// </summary>
+		/// <param name="predicate"></param>
+		/// <param name="predicateType"></param>
+		/// <param name="predicateList"></param>
+		/// <param name="sqlParamsList"></param>
+		/// <param name="sortOrder"></param>
+		/// <param name="appendParam"></param>
+		internal static void AddPredicate<T>( Expression<Func<T, bool>> predicate, PredicateType predicateType, List<Condition> predicateList,
+			List<SqlParameter> sqlParamsList, int sortOrder, string appendParam )
+		{
+			string leftName;
+			string value;
+			Condition condition;
+
+			BinaryExpression binaryBody = predicate.Body as BinaryExpression;
+
+			if ( binaryBody == null )
                 throw new SqlBulkToolsException($"Expression not supported for {GetPredicateMethodName(predicateType)}");
 
-            // For expression types Equal and NotEqual, it's possible for user to pass null value. This handles the null use case. 
-            // SqlParameter is not added when comparison to null value is used. 
-            switch (predicate.Body.NodeType)
-            {
-                case ExpressionType.NotEqual:
-                    {
-                        leftName = ((MemberExpression)binaryBody.Left).Member.Name;
-                        value = Expression.Lambda(binaryBody.Right).Compile().DynamicInvoke()?.ToString();
+			// For expression types Equal and NotEqual, it's possible for user to pass null value. This handles the null use case. 
+			// SqlParameter is not added when comparison to null value is used. 
+			switch ( predicate.Body.NodeType )
+			{
+				case ExpressionType.NotEqual:
+					{
+						leftName = ( (MemberExpression)binaryBody.Left ).Member.Name;
+						value = Expression.Lambda( binaryBody.Right ).Compile().DynamicInvoke()?.ToString();
 
 
-                        if (value != null)
-                        {
-                            condition = new Condition()
-                            {
-                                Expression = ExpressionType.NotEqual,
-                                LeftName = leftName,
-                                ValueType = binaryBody.Right.Type,
-                                Value = value,
-                                PredicateType = predicateType,
-                                SortOrder = sortOrder
-                            };
+						if ( value != null )
+						{
+							condition = new Condition()
+							{
+								Expression = ExpressionType.NotEqual,
+								LeftName = leftName,
+								ValueType = binaryBody.Right.Type,
+								Value = value,
+								PredicateType = predicateType,
+								SortOrder = sortOrder
+							};
 
-                            DbType sqlType = SqlTypeMap.GetSqlTypeFromNetType(condition.ValueType);
+							DbType sqlType = SqlTypeMap.GetSqlTypeFromNetType( condition.ValueType );
 
-                            string paramName = appendParam != null ? leftName + appendParam + sortOrder : leftName;
-                            SqlParameter param = new SqlParameter($"@{paramName}", sqlType);
-                            param.Value = condition.Value;
-                            sqlParamsList.Add(param);
-                        }
-                        else
-                        {
-                            condition = new Condition()
-                            {
-                                Expression = ExpressionType.NotEqual,
-                                LeftName = leftName,
-                                Value = "NULL",
-                                PredicateType = predicateType,
-                                SortOrder = sortOrder
-                            };
-                        }
+							string paramName = appendParam != null ? leftName + appendParam + sortOrder : leftName;
+							SqlParameter param = new SqlParameter( $"@{paramName}", sqlType );
+							param.Value = condition.Value;
+							sqlParamsList.Add( param );
+						}
+						else
+						{
+							condition = new Condition()
+							{
+								Expression = ExpressionType.NotEqual,
+								LeftName = leftName,
+								Value = "NULL",
+								PredicateType = predicateType,
+								SortOrder = sortOrder
+							};
+						}
 
-                        predicateList.Add(condition);
+						predicateList.Add( condition );
 
 
-                        break;
-                    }
+						break;
+					}
 
-                // For expression types Equal and NotEqual, it's possible for user to pass null value. This handles the null use case. 
-                // SqlParameter is not added when comparison to null value is used. 
-                case ExpressionType.Equal:
-                    {
-                        leftName = ((MemberExpression)binaryBody.Left).Member.Name;
-                        value = Expression.Lambda(binaryBody.Right).Compile().DynamicInvoke()?.ToString();
+				// For expression types Equal and NotEqual, it's possible for user to pass null value. This handles the null use case. 
+				// SqlParameter is not added when comparison to null value is used. 
+				case ExpressionType.Equal:
+					{
+						leftName = ( (MemberExpression)binaryBody.Left ).Member.Name;
+						value = Expression.Lambda( binaryBody.Right ).Compile().DynamicInvoke()?.ToString();
 
-                        if (value != null)
-                        {
-                            condition = new Condition()
-                            {
-                                Expression = ExpressionType.Equal,
-                                LeftName = leftName,
-                                ValueType = binaryBody.Right.Type,
-                                Value = value, 
-                                PredicateType = predicateType,
-                                SortOrder = sortOrder
-                            };
+						if ( value != null )
+						{
+							condition = new Condition()
+							{
+								Expression = ExpressionType.Equal,
+								LeftName = leftName,
+								ValueType = binaryBody.Right.Type,
+								Value = value,
+								PredicateType = predicateType,
+								SortOrder = sortOrder
+							};
 
-                            DbType sqlType = SqlTypeMap.GetSqlTypeFromNetType(condition.ValueType);
-                            string paramName = appendParam != null ? leftName + appendParam + sortOrder : leftName;
-                            SqlParameter param = new SqlParameter($"@{paramName}", sqlType);
-                            param.Value = condition.Value;
-                            sqlParamsList.Add(param);
-                        }
-                        else
-                        {
-                            condition = new Condition()
-                            {
-                                Expression = ExpressionType.Equal,
-                                LeftName = leftName,
-                                Value = "NULL", 
-                                PredicateType = predicateType,
-                                SortOrder = sortOrder
-                            };
-                        }
+							DbType sqlType = SqlTypeMap.GetSqlTypeFromNetType( condition.ValueType );
+							string paramName = appendParam != null ? leftName + appendParam + sortOrder : leftName;
+							SqlParameter param = new SqlParameter( $"@{paramName}", sqlType );
+							param.Value = condition.Value;
+							sqlParamsList.Add( param );
+						}
+						else
+						{
+							condition = new Condition()
+							{
+								Expression = ExpressionType.Equal,
+								LeftName = leftName,
+								Value = "NULL",
+								PredicateType = predicateType,
+								SortOrder = sortOrder
+							};
+						}
 
-                            predicateList.Add(condition);
+						predicateList.Add( condition );
 
-                        break;
-                    }
-                case ExpressionType.LessThan:
-                    {
-                        leftName = ((MemberExpression)binaryBody.Left).Member.Name;
-                        value = Expression.Lambda(binaryBody.Right).Compile().DynamicInvoke()?.ToString();
-                        BuildCondition(leftName, value, binaryBody.Right.Type, ExpressionType.LessThan, predicateList, sqlParamsList, 
-                            predicateType, sortOrder, appendParam);
-                        break;
-                    }
-                case ExpressionType.LessThanOrEqual:
-                    {
-                        leftName = ((MemberExpression)binaryBody.Left).Member.Name;
-                        value = Expression.Lambda(binaryBody.Right).Compile().DynamicInvoke()?.ToString();
-                        BuildCondition(leftName, value, binaryBody.Right.Type, ExpressionType.LessThanOrEqual, predicateList, 
-                            sqlParamsList, predicateType, sortOrder, appendParam);
-                        break;
-                    }
-                case ExpressionType.GreaterThan:
-                    {
-                        leftName = ((MemberExpression)binaryBody.Left).Member.Name;
-                        value = Expression.Lambda(binaryBody.Right).Compile().DynamicInvoke()?.ToString();
-                        BuildCondition(leftName, value, binaryBody.Right.Type, ExpressionType.GreaterThan, predicateList, 
-                            sqlParamsList, predicateType, sortOrder, appendParam);
-                        break;
-                    }
-                case ExpressionType.GreaterThanOrEqual:
-                    {
-                        leftName = ((MemberExpression)binaryBody.Left).Member.Name;
-                        value = Expression.Lambda(binaryBody.Right).Compile().DynamicInvoke()?.ToString();
-                        BuildCondition(leftName, value, binaryBody.Right.Type, ExpressionType.GreaterThanOrEqual, predicateList, 
-                            sqlParamsList, predicateType, sortOrder, appendParam);
-                        break;
-                    }
-                case ExpressionType.AndAlso:
-                    {
+						break;
+					}
+				case ExpressionType.LessThan:
+					{
+						leftName = ( (MemberExpression)binaryBody.Left ).Member.Name;
+						value = Expression.Lambda( binaryBody.Right ).Compile().DynamicInvoke()?.ToString();
+						BuildCondition( leftName, value, binaryBody.Right.Type, ExpressionType.LessThan, predicateList, sqlParamsList,
+							predicateType, sortOrder, appendParam );
+						break;
+					}
+				case ExpressionType.LessThanOrEqual:
+					{
+						leftName = ( (MemberExpression)binaryBody.Left ).Member.Name;
+						value = Expression.Lambda( binaryBody.Right ).Compile().DynamicInvoke()?.ToString();
+						BuildCondition( leftName, value, binaryBody.Right.Type, ExpressionType.LessThanOrEqual, predicateList,
+							sqlParamsList, predicateType, sortOrder, appendParam );
+						break;
+					}
+				case ExpressionType.GreaterThan:
+					{
+						leftName = ( (MemberExpression)binaryBody.Left ).Member.Name;
+						value = Expression.Lambda( binaryBody.Right ).Compile().DynamicInvoke()?.ToString();
+						BuildCondition( leftName, value, binaryBody.Right.Type, ExpressionType.GreaterThan, predicateList,
+							sqlParamsList, predicateType, sortOrder, appendParam );
+						break;
+					}
+				case ExpressionType.GreaterThanOrEqual:
+					{
+						leftName = ( (MemberExpression)binaryBody.Left ).Member.Name;
+						value = Expression.Lambda( binaryBody.Right ).Compile().DynamicInvoke()?.ToString();
+						BuildCondition( leftName, value, binaryBody.Right.Type, ExpressionType.GreaterThanOrEqual, predicateList,
+							sqlParamsList, predicateType, sortOrder, appendParam );
+						break;
+					}
+				case ExpressionType.AndAlso:
+					{
                         throw new SqlBulkToolsException($"And && expression not supported for {GetPredicateMethodName(predicateType)}. " +
                                                         $"Try chaining predicates instead e.g. {GetPredicateMethodName(predicateType)}." +
                                                         $"{GetPredicateMethodName(predicateType)}");
-                    }
-                case ExpressionType.OrElse:
-                    {
+					}
+				case ExpressionType.OrElse:
+					{
                         throw new SqlBulkToolsException($"Or || expression not supported for {GetPredicateMethodName(predicateType)}.");
-                    }
+					}
 
-                default:
-                    {
+				default:
+					{
                         throw new SqlBulkToolsException($"Expression used in {GetPredicateMethodName(predicateType)} not supported. " +
-                                                        $"Only == != < <= > >= expressions are accepted.");
-                    }
-            }
-        }
+														$"Only == != < <= > >= expressions are accepted." );
+					}
+			}
+		}
 
-        /// <summary>
-        /// 
-        /// </summary>
-        /// <param name="predicateType"></param>
-        /// <returns></returns>
-        internal static string GetPredicateMethodName(PredicateType predicateType)
-        {
-            return predicateType == PredicateType.Update
-                ? "UpdateWhen(...)"
-                : predicateType == PredicateType.Delete ?
-                "DeleteWhen(...)"
-                : predicateType == PredicateType.Where ? 
-                "Where(...)"
-                : predicateType == PredicateType.And ?
-                "And(...)"
-                : predicateType == PredicateType.Or ?
-                "Or(...)"
-                : string.Empty;
-        }
+		/// <summary>
+		/// 
+		/// </summary>
+		/// <param name="predicateType"></param>
+		/// <returns></returns>
+		internal static string GetPredicateMethodName( PredicateType predicateType )
+		{
+			return predicateType == PredicateType.Update
+				? "UpdateWhen(...)"
+				: predicateType == PredicateType.Delete ?
+				"DeleteWhen(...)"
+				: predicateType == PredicateType.Where ?
+				"Where(...)"
+				: predicateType == PredicateType.And ?
+				"And(...)"
+				: predicateType == PredicateType.Or ?
+				"Or(...)"
+				: string.Empty;
+		}
 
-        /// <summary>
-        /// 
-        /// </summary>
-        /// <param name="leftName"></param>
-        /// <param name="value"></param>
-        /// <param name="valueType"></param>
-        /// <param name="expressionType"></param>
-        /// <param name="predicateList"></param>
-        /// <param name="sqlParamsList"></param>
-        /// <param name="sortOrder"></param>
-        /// <param name="appendParam"></param>
-        /// <param name="predicateType"></param>
-        internal static void BuildCondition(string leftName, string value, Type valueType, ExpressionType expressionType, 
-            List<Condition> predicateList, List<SqlParameter> sqlParamsList, PredicateType predicateType, int sortOrder, string appendParam)
-        {
+		/// <summary>
+		/// 
+		/// </summary>
+		/// <param name="leftName"></param>
+		/// <param name="value"></param>
+		/// <param name="valueType"></param>
+		/// <param name="expressionType"></param>
+		/// <param name="predicateList"></param>
+		/// <param name="sqlParamsList"></param>
+		/// <param name="sortOrder"></param>
+		/// <param name="appendParam"></param>
+		/// <param name="predicateType"></param>
+		internal static void BuildCondition( string leftName, string value, Type valueType, ExpressionType expressionType,
+			List<Condition> predicateList, List<SqlParameter> sqlParamsList, PredicateType predicateType, int sortOrder, string appendParam )
+		{
 
-            Condition condition = new Condition()
-            {
-                Expression = expressionType,
-                LeftName = leftName,
-                ValueType = valueType,
-                Value = value, 
-                PredicateType = predicateType,
-                SortOrder = sortOrder
-            };
+			Condition condition = new Condition()
+			{
+				Expression = expressionType,
+				LeftName = leftName,
+				ValueType = valueType,
+				Value = value,
+				PredicateType = predicateType,
+				SortOrder = sortOrder
+			};
 
-            predicateList.Add(condition);
+			predicateList.Add( condition );
 
 
-            DbType sqlType = SqlTypeMap.GetSqlTypeFromNetType(condition.ValueType);
-            string paramName = appendParam != null ? leftName + appendParam + sortOrder : leftName;
-            SqlParameter param = new SqlParameter($"@{paramName}", sqlType);
-            param.Value = condition.Value;
-            sqlParamsList.Add(param);
+			DbType sqlType = SqlTypeMap.GetSqlTypeFromNetType( condition.ValueType );
+			string paramName = appendParam != null ? leftName + appendParam + sortOrder : leftName;
+			SqlParameter param = new SqlParameter( $"@{paramName}", sqlType );
+			param.Value = condition.Value;
+			sqlParamsList.Add( param );
 
-        }
-    }
+		}
+	}
 }


### PR DESCRIPTION
We needed the ability to have multiple bulk operations use the same connection and transaction.

Updated the BulkOperations to support passing in a SqlTransaction (optional) in the CommitTransaction calls with a SqlConnection.
All the ITransactions updated to take a SqlTransaction in their CommitTransaction implementations.
If the connection is not open, assumes that it should handle its connection internally and work as previously written, if it is open then leaves the connection alone to be handled outside.
If the transaction is null, assumed that it should handle its transaction internally and work as previously written, it it is not null, leaves the transaction alone to be handled outside.

BulkOperationsHelper.GetDatabaseSchema needed to be modified because SqlConnection.GetSchema will throw an exception if it's called on a connection with a transaction.

Please let me know your thoughts. Is there a better/cleaner way of doing this? For lack of time on my current project I didn't want to write a whole new method, but would that be better than tacking this functionality into CommitTransaction?

I did not get databases setup to support running of the unit test, so they have not been run. I tried to make my changes so that all the existing unit tests would continue pass.
