### PR TITLE
SpeedUp ConvertListToDataTable method

### DIFF
--- a/SqlBulkTools/Helper/BulkOperationsHelper.cs
+++ b/SqlBulkTools/Helper/BulkOperationsHelper.cs
@@ -661,6 +661,8 @@ namespace SqlBulkTools
         public static DataTable ConvertListToDataTable<T>(List<PropertyInfo> propertyInfoList, DataTable dataTable, IEnumerable<T> list, HashSet<string> columns, Dictionary<string, int> ordinalDic,
             Dictionary<int, T> outputIdentityDic = null)
         {
+            Dictionary<PropertyInfo, Attribute> propertyCustomAttributeDictionary 
+                = propertyInfoList.ToDictionary(pi => pi, pi => pi.PropertyType.GetCustomAttribute(typeof(ComplexTypeAttribute)));
 
             int internalIdCounter = 0;
 
@@ -671,7 +673,9 @@ namespace SqlBulkTools
                 {
                     foreach (var property in propertyInfoList)
                     {
-                        if (property.PropertyType.GetCustomAttribute(typeof(ComplexTypeAttribute)) != null)
+                        Attribute attr;
+                        bool res = propertyCustomAttributeDictionary.TryGetValue(property, out attr);
+                        if (res && attr != null)
                         {
                             var complexPropertyList = property.PropertyType.GetProperties();
 


### PR DESCRIPTION
In the loop, the "property.PropertyType.GetCustomAttribute (typeof (ComplexTypeAttribute))" method is often called. " On large collections - this creates a great delay.
For example, when I insert 22,000 elements, the insertion takes 2.5 seconds.
By placing this method before the loops, by running a query on the "ComplexTypeAttribute" and placing the result in the dictionary, we save a considerable amount of time.
As a result, I inserted about 22,000 elements in about 0.5 seconds.
Sorry for the errors, this is my first pull request.